### PR TITLE
Add full-archive site search with Pagefind (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@astrojs/check": "^0.9.9",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.1",
+        "pagefind": "^1.5.2",
         "satori": "^0.12.0",
         "sharp": "^0.35.1",
         "tailwindcss": "^4.3.1",
@@ -1400,6 +1401,104 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
@@ -6572,6 +6671,25 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/pako": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Personal site + blog for mattstratton.com (migrated from Hugo to Astro)",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "migrate": "tsx scripts/migrate-posts.ts",
@@ -23,6 +23,7 @@
     "@astrojs/check": "^0.9.9",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.1",
+    "pagefind": "^1.5.2",
     "satori": "^0.12.0",
     "sharp": "^0.35.1",
     "tailwindcss": "^4.3.1",

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,0 +1,194 @@
+---
+/**
+ * Full-archive site search. A nav trigger opens a modal that searches every
+ * content page (posts, writing, standalone pages) via Pagefind.
+ *
+ * Pagefind indexes the built HTML in a postbuild step (`pagefind --site dist`),
+ * producing a chunked index under /pagefind/ that scales to thousands of pages
+ * without shipping a giant JSON blob. The index only exists after a build, so
+ * search works in `astro preview` / production, NOT in `astro dev` (the script
+ * fails gracefully there).
+ */
+---
+
+<button
+  type="button"
+  data-search-open
+  aria-haspopup="dialog"
+  aria-expanded="false"
+  class="label !text-[0.78rem] inline-flex items-center gap-1.5 transition-colors hover:text-accent"
+>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" />
+    <path d="m20 20-3.2-3.2" stroke-linecap="round" />
+  </svg>
+  <span class="sr-only sm:not-sr-only">Search</span>
+</button>
+
+<div data-search-overlay role="dialog" aria-modal="true" aria-labelledby="search-title" hidden class="fixed inset-0 z-50">
+  <div data-search-backdrop class="absolute inset-0 bg-ink/40 backdrop-blur-sm"></div>
+
+  <div class="absolute inset-0 flex flex-col bg-panel sm:inset-x-0 sm:top-0 sm:mx-auto sm:my-16 sm:max-h-[80vh] sm:max-w-2xl sm:rounded-lg sm:border sm:border-rule sm:shadow-xl">
+    <h2 id="search-title" class="sr-only">Search the site</h2>
+
+    <div class="flex items-center gap-2 border-b border-rule px-4 py-3">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-5 w-5 shrink-0 text-ink-soft" aria-hidden="true">
+        <circle cx="11" cy="11" r="7" />
+        <path d="m20 20-3.2-3.2" stroke-linecap="round" />
+      </svg>
+      <input
+        type="search"
+        data-search-input
+        aria-label="Search the site"
+        placeholder="Search posts, writing, pages…"
+        autocomplete="off"
+        class="min-w-0 flex-1 bg-transparent py-2 font-sans text-lg text-ink placeholder:text-ink-soft focus:outline-none"
+      />
+      <button type="button" data-search-close aria-label="Close search" class="flex h-11 w-11 shrink-0 items-center justify-center rounded text-ink-soft transition-colors hover:text-accent">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-5 w-5" aria-hidden="true">
+          <path d="M6 6 18 18M18 6 6 18" stroke-linecap="round" />
+        </svg>
+      </button>
+    </div>
+
+    <p data-search-status role="status" aria-live="polite" class="label px-4 pt-3 pb-1"></p>
+    <ul data-search-results class="flex-1 overflow-y-auto px-4 pb-4"></ul>
+  </div>
+</div>
+
+<style is:global>
+  [data-search-results] mark {
+    background: color-mix(in srgb, var(--color-accent-bright) 28%, transparent);
+    color: inherit;
+    border-radius: 2px;
+  }
+</style>
+
+<script>
+  const overlay = document.querySelector<HTMLElement>('[data-search-overlay]');
+  const openBtn = document.querySelector<HTMLButtonElement>('[data-search-open]');
+  const closeBtn = document.querySelector<HTMLButtonElement>('[data-search-close]');
+  const backdrop = document.querySelector<HTMLElement>('[data-search-backdrop]');
+  const input = document.querySelector<HTMLInputElement>('[data-search-input]');
+  const status = document.querySelector<HTMLElement>('[data-search-status]');
+  const results = document.querySelector<HTMLUListElement>('[data-search-results]');
+
+  if (overlay && openBtn && closeBtn && backdrop && input && status && results) {
+    let pagefind: any = null;
+    let loadFailed = false;
+    let lastFocused: HTMLElement | null = null;
+    const MAX = 30;
+
+    const escapeHtml = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+    async function ensurePagefind() {
+      if (pagefind || loadFailed) return;
+      try {
+        // Runtime path (built into dist/pagefind/); hidden from the bundler.
+        const path = '/pagefind/pagefind.js';
+        pagefind = await import(/* @vite-ignore */ path);
+        await pagefind.options({ excerptLength: 24 });
+      } catch {
+        loadFailed = true;
+      }
+    }
+
+    function renderEmpty(query: string) {
+      results!.innerHTML = '';
+      if (loadFailed) {
+        status!.textContent = 'Search runs on the built site (not the dev server).';
+      } else {
+        status!.textContent = query ? '' : 'Type to search the whole site.';
+      }
+    }
+
+    async function run() {
+      const q = input!.value.trim();
+      if (!q) {
+        renderEmpty('');
+        return;
+      }
+      await ensurePagefind();
+      if (!pagefind) {
+        renderEmpty(q);
+        return;
+      }
+      const search = await pagefind.search(q);
+      // Ignore a stale query that resolved after the user kept typing.
+      if (q !== input!.value.trim()) return;
+
+      const items = await Promise.all(search.results.slice(0, MAX).map((r: any) => r.data()));
+      if (items.length === 0) {
+        results!.innerHTML = '';
+        status!.textContent = 'No results.';
+        return;
+      }
+      status!.textContent = `${search.results.length} result${search.results.length === 1 ? '' : 's'}${search.results.length > MAX ? ` (showing ${MAX})` : ''}`;
+      results!.innerHTML = items
+        .map((d: any) => {
+          const title = escapeHtml(d.meta?.title ?? d.url);
+          return `<li><a href="${escapeHtml(d.url)}" class="group block border-b border-rule py-3 transition-colors hover:bg-paper">
+            <h3 class="font-display text-base font-medium leading-snug text-balance decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">${title}</h3>
+            <p class="mt-1 text-sm leading-snug text-ink-soft">${d.excerpt}</p>
+          </a></li>`;
+        })
+        .join('');
+    }
+
+    let debounce: number;
+    input.addEventListener('input', () => {
+      clearTimeout(debounce);
+      debounce = window.setTimeout(run, 140);
+    });
+
+    async function open() {
+      lastFocused = document.activeElement as HTMLElement | null;
+      overlay!.removeAttribute('hidden');
+      openBtn!.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+      input!.focus();
+      await ensurePagefind();
+      renderEmpty(input!.value.trim());
+    }
+    function close() {
+      overlay!.setAttribute('hidden', '');
+      openBtn!.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+      lastFocused?.focus();
+    }
+
+    openBtn.addEventListener('click', open);
+    closeBtn.addEventListener('click', close);
+    backdrop.addEventListener('click', close);
+
+    // `/` opens search unless the user is typing in a field.
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== '/' || !overlay!.hasAttribute('hidden')) return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      e.preventDefault();
+      open();
+    });
+
+    overlay.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusable = overlay!.querySelectorAll<HTMLElement>('a[href], button:not([disabled]), input:not([disabled])');
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
+  }
+</script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import Search from '../components/Search.astro';
 
 interface Props {
   title: string;
@@ -95,6 +96,7 @@ const nav = [
               {item.label}{item.external && <span aria-hidden="true"> ↗</span>}
             </a>
           ))}
+          <Search />
         </div>
       </nav>
     </header>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -10,7 +10,7 @@ const { frontmatter } = Astro.props;
 ---
 
 <Base title={`${frontmatter.title} · Matty Stratton`} description={frontmatter.description}>
-  <article class="mx-auto max-w-2xl">
+  <article class="mx-auto max-w-2xl" data-pagefind-body>
     <header class="border-b-2 border-ink pb-6">
       <h1 class="font-display text-4xl font-bold tracking-tight text-balance sm:text-5xl">{frontmatter.title}</h1>
     </header>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -17,9 +17,9 @@ const date = d.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long'
   type="article"
   publishedTime={d.date.toISOString()}
 >
-  <article class="mx-auto max-w-2xl">
+  <article class="mx-auto max-w-2xl" data-pagefind-body>
     <header class="border-b-2 border-ink pb-6">
-      <p class="label">From the archive</p>
+      <p class="label" data-pagefind-ignore>From the archive</p>
       <h1 class="mt-3 font-display text-4xl font-bold leading-tight tracking-tight text-balance sm:text-5xl">
         {d.title}
       </h1>

--- a/src/layouts/WritingLayout.astro
+++ b/src/layouts/WritingLayout.astro
@@ -22,7 +22,7 @@ const updated = d.updatedDate?.toLocaleDateString('en-US', { year: 'numeric', mo
   canonicalUrl={d.canonicalUrl}
   image={`/og/writing/${entry.id}.png`}
 >
-  <article class="mx-auto max-w-2xl">
+  <article class="mx-auto max-w-2xl" data-pagefind-body>
     <header class="border-b-2 border-ink pb-6">
       {partLabel && <p class="label">{partLabel}</p>}
       <h1 class="mt-3 font-display text-4xl font-bold leading-tight tracking-tight text-balance sm:text-5xl">


### PR DESCRIPTION
Closes #14.

Adds full-archive search using [Pagefind](https://pagefind.app/), which is built for exactly this scale — it indexes the built HTML in a postbuild step and serves a chunked index, so there's no giant client-side JSON to download.

## How it works
- `build` is now `astro build && pagefind --site dist` (Pagefind runs after Astro, indexing `dist/`)
- **2,631 content pages indexed** — only real content via `data-pagefind-body` on the post/writing/page `<article>` elements. Nav and listing pages (`/post`, `/categories`, `/tags`, homepage) are excluded, so results are actual posts, not index pages.
- `Search.astro` is a nav-triggered modal matching the speaking site's UX (`/` to open, Esc to close, focus trap), but using Pagefind's JS API with results rendered in the site's own styling (title + highlighted excerpt + result count, capped at 30 shown).

## Verified in preview
- "chef cookbook" → 1 result (Getting Started with Chef)
- "devops" → 4 results across the archive, with `<mark>` highlights

## Notes
- Search works on the **built/preview site and production**, not `astro dev` (the index only exists after a build). The script fails gracefully in dev with a "runs on the built site" message.
- Pagefind's binary is fetched on `npm install`, so the Netlify build picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)