### PR TITLE
Newsletter (Uncommitted) + Postgres field guide at /writing (#16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ dist/
 .astro/
 .netlify/
 
+# Secrets (Buttondown API key etc.) — never commit
+.env
+.env.*
+
 # General CodeKit files to ignore
 config.codekit
 /min

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@ Node **20** (see `netlify.toml`). Netlify builds via `npm run build`, publishes 
 
 **Static assets**: `public/` is served at the root path (img/, wp-content/, fav.png, CV PDF). `public/wp-content/` (76MB) holds legacy post images; ~760 are unreferenced WordPress variants and could be pruned after a careful srcset-aware audit.
 
+## Environment variables
+
+- `BUTTONDOWN_API_KEY` — used by `src/lib/buttondown.ts` to fetch the newsletter archive at build. Set it in Netlify's env vars and in a local `.env` (gitignored). If absent, the archive builds empty (no failure). Generate it in Buttondown → Settings → API. To refresh the archive when a new issue sends, point a Buttondown webhook at a Netlify build hook.
+- `BUTTONDOWN_API_BASE` — optional override if Buttondown moves the API base off `api.buttondown.email/v1`.
+
+The signup form is driven by `newsletter.buttondownUser` in `src/data/home.ts` (public username, not a secret).
+
 ## Migration history
 
 The original Hugo source (`content/`, `config.yml`, `layouts/`, `themes/hugo-profile`, `bin/`, `static/`) was **removed** after the Astro site was confirmed in production. It lives in git history if ever needed — `scripts/migrate-posts.ts` still documents the legacy-post transformation, but re-running it would require restoring `content/post/` from history first. The migrated posts in `src/content/posts/` are now the source of truth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@astrojs/sitemap": "^3.7.3",
         "@fontsource-variable/hanken-grotesk": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "astro": "^5.18.2"
+        "astro": "^5.18.2",
+        "marked": "^18.0.5"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
@@ -5698,6 +5699,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@astrojs/sitemap": "^3.7.3",
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "astro": "^5.18.2"
+    "astro": "^5.18.2",
+    "marked": "^18.0.5"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/public/_redirects
+++ b/public/_redirects
@@ -22,8 +22,8 @@
 /about/about/      /#about       301
 /page/contact      /#contact     301
 /page/contact/     /#contact     301
-/page/newsletter   /#newsletter  301
-/page/newsletter/  /#newsletter  301
+/page/newsletter   /newsletter/  301
+/page/newsletter/  /newsletter/  301
 /page              /             301
 /page/             /             301
 

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -16,6 +16,7 @@ const action = user ? `https://buttondown.com/api/emails/embed-subscribe/${user}
   {action ? (
     <form action={action} method="post" target="_blank" class="mt-5 flex max-w-md flex-wrap gap-3">
       <label for="bd-email" class="sr-only">Email address</label>
+      <input type="hidden" name="embed" value="1" />
       <input
         id="bd-email"
         type="email"

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -16,7 +16,6 @@ const action = user ? `https://buttondown.com/api/emails/embed-subscribe/${user}
   {action ? (
     <form action={action} method="post" target="_blank" class="mt-5 flex max-w-md flex-wrap gap-3">
       <label for="bd-email" class="sr-only">Email address</label>
-      <input type="hidden" name="embed" value="1" />
       <input
         id="bd-email"
         type="email"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
+import { buttondownLoader } from './lib/buttondown';
 
 // The evergreen Postgres "field guide" authored on mattstratton.com going
 // forward. Separate from the legacy `posts` archive (added in the post-migration
@@ -46,4 +47,16 @@ const posts = defineCollection({
   }),
 });
 
-export const collections = { writing, posts };
+// Newsletter archive, pulled from Buttondown at build time (see src/lib/buttondown.ts).
+const newsletter = defineCollection({
+  loader: buttondownLoader(),
+  schema: z.object({
+    subject: z.string(),
+    slug: z.string(),
+    publishDate: z.coerce.date(),
+    bodyHtml: z.string(),
+    excerpt: z.string().default(''),
+  }),
+});
+
+export const collections = { writing, posts, newsletter };

--- a/src/data/field-guide.ts
+++ b/src/data/field-guide.ts
@@ -1,0 +1,124 @@
+// External entries for the Postgres field guide at /writing. These point at
+// posts published on tigerdata.com (the "founding content" of the collection,
+// per matty-writing-plan.md). Native posts authored on this site (the `writing`
+// collection) slot into the same 4-part arc alongside these.
+//
+// URLs/descriptions sourced from Tiger Den (the marketing content index), so
+// they're real, not guessed. Add newer posts here as the guide grows.
+
+export type PartKey = 'mechanics' | 'limits' | 'traps' | 'decision';
+
+export interface FieldGuideLink {
+  title: string;
+  description: string;
+  part: PartKey;
+  url: string;
+}
+
+export const externalFieldGuide: FieldGuideLink[] = [
+  // Part 1 — What's happening inside Postgres
+  {
+    title: 'MVCC: The Feature You’re Paying For But Not Using',
+    description:
+      'MVCC is great for concurrent workloads. For append-only data, it’s 23 bytes of overhead per row that never gets used. Here’s what that actually costs.',
+    part: 'mechanics',
+    url: 'https://www.tigerdata.com/blog/mvcc-feature-youre-paying-for-but-not-using',
+  },
+  {
+    title: 'Write Amplification in Postgres: The 3-4x Tax on Every Insert',
+    description:
+      'Every 1 KB insert in Postgres becomes ~2.5 KB of committed I/O before it’s done. Here’s where the multiplier comes from, and where the tuning knobs run out.',
+    part: 'mechanics',
+    url: 'https://www.tigerdata.com/blog/write-amplification-in-postgres-the-3-4x-tax-on-every-insert',
+  },
+  {
+    title: 'When Continuous Ingestion Breaks Traditional Postgres',
+    description:
+      'Postgres maintenance depends on quiet periods your continuous workload eliminated. Here’s what happens inside the database when the gaps disappear.',
+    part: 'mechanics',
+    url: 'https://www.tigerdata.com/blog/when-continuous-ingestion-breaks-traditional-postgres',
+  },
+
+  // Part 2 — Why you're hitting the wall
+  {
+    title: 'Understanding Postgres Performance Limits for Analytics on Live Data',
+    description:
+      'PostgreSQL hits hard limits under analytics workloads. Here’s why MVCC, WAL, and row storage compound, and what to do instead.',
+    part: 'limits',
+    url: 'https://www.tigerdata.com/blog/postgres-optimization-treadmill',
+  },
+  {
+    title: 'Six Signs That Postgres Tuning Won’t Fix Your Performance Problems',
+    description:
+      'When Postgres tuning won’t fix performance: recognize the six characteristics of time-series workloads that need a purpose-built architecture.',
+    part: 'limits',
+    url: 'https://www.tigerdata.com/blog/six-signs-postgres-tuning-wont-fix-performance-problems',
+  },
+  {
+    title: 'Postgres Performance: Why Peak Throughput Benchmarks Miss the Real Problem',
+    description:
+      'Peak throughput tells you what Postgres can do in a sprint. Production asks what it can do forever. Those are different questions.',
+    part: 'limits',
+    url: 'https://www.tigerdata.com/blog/postgres-performance-why-peak-throughput-benchmarks-miss-real-problem',
+  },
+  {
+    title: 'Vertical Scaling: Buying Time You Can’t Afford',
+    description:
+      'Postgres vertical scaling works, until it doesn’t. Why high-frequency ingestion workloads hit an architectural wall, and what to do about it.',
+    part: 'limits',
+    url: 'https://www.tigerdata.com/blog/vertical-scaling-buying-time-you-cant-afford',
+  },
+
+  // Part 3 — The traps
+  {
+    title: 'Why Adding More Indexes Eventually Makes Things Worse',
+    description:
+      'Every Postgres index is a flat tax on every insert. At high ingestion rates, that tax is the whole problem.',
+    part: 'traps',
+    url: 'https://www.tigerdata.com/blog/why-adding-more-indexes-eventually-makes-things-worse',
+  },
+  {
+    title: 'The Hidden Costs of Table Partitioning at Scale',
+    description:
+      'Table partitioning fixes retention and pruning, but adds hidden costs in planning time, schema migrations, and ops overhead. Know the tradeoffs before you commit.',
+    part: 'traps',
+    url: 'https://www.tigerdata.com/blog/hidden-costs-table-partitioning-scale',
+  },
+  {
+    title: 'Read Replicas Don’t Solve Write Bottlenecks',
+    description:
+      'Read replicas fix read contention. They don’t fix write throughput. Here’s the mechanical reason why, and what actually changes the trajectory.',
+    part: 'traps',
+    url: 'https://www.tigerdata.com/blog/read-replicas-dont-solve-write-bottlenecks',
+  },
+
+  // Part 4 — The decision
+  {
+    title: 'Optimization vs. Architecture: Knowing the Difference',
+    description:
+      'Optimization problems stay fixed. Architectural ones come back. A framework for knowing which you’re dealing with before you’ve spent months on the wrong fix.',
+    part: 'decision',
+    url: 'https://www.tigerdata.com/blog/optimization-vs-architecture-knowing-the-difference',
+  },
+  {
+    title: 'The Best Time to Migrate Was at 10M Rows. The Second Best Time Is Now.',
+    description:
+      'Migration cost scales with data volume. The optimization tax you pay while waiting scales faster.',
+    part: 'decision',
+    url: 'https://www.tigerdata.com/blog/when-to-migrate-postgres-to-timescaledb',
+  },
+  {
+    title: 'Document Databases: Be Honest',
+    description:
+      'Most MongoDB pain isn’t a MongoDB problem. It’s a workload shape problem that would follow you to Postgres.',
+    part: 'decision',
+    url: 'https://www.tigerdata.com/blog/document-databases-be-honest',
+  },
+  {
+    title: 'ClickHouse Is Fast. Your Pipeline Isn’t.',
+    description:
+      'ClickHouse is fast. But the pipeline tax, ACID trade-offs, and two-system overhead are part of the decision too. Here’s the full picture.',
+    part: 'decision',
+    url: 'https://www.tigerdata.com/blog/clickhouse-is-fast-your-pipeline-isnt',
+  },
+];

--- a/src/data/home.ts
+++ b/src/data/home.ts
@@ -219,9 +219,9 @@ export const speaking = {
 };
 
 export const newsletter = {
-  title: 'Stay in the Loop',
+  title: 'Uncommitted',
   content:
-    'New posts on Postgres internals and performance, delivered when something worth reading ships.',
+    'Monthly dispatches on Postgres internals, performance, and whatever else is rattling around in my head.',
   // Public Buttondown username (not a secret) — drives the embed signup form.
   buttondownUser: 'mattstratton' as string | null,
 };

--- a/src/data/home.ts
+++ b/src/data/home.ts
@@ -222,9 +222,8 @@ export const newsletter = {
   title: 'Stay in the Loop',
   content:
     'New posts on Postgres internals and performance, delivered when something worth reading ships.',
-  // Set this once the Buttondown account exists; until then the form renders a
-  // disabled placeholder (see Newsletter.astro).
-  buttondownUser: null as string | null,
+  // Public Buttondown username (not a secret) — drives the embed signup form.
+  buttondownUser: 'mattstratton' as string | null,
 };
 
 export const contact = {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,6 +25,7 @@ const isActive = (p: string) => path === p || (p !== '/' && path.startsWith(p));
 
 const nav = [
   { href: '/writing/', label: 'Writing' },
+  { href: '/newsletter/', label: 'Newsletter' },
   { href: '/post/', label: 'Archive' },
   { href: '/#about', label: 'About' },
   { href: 'https://speaking.mattstratton.com', label: 'Speaking', external: true },

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -110,6 +110,7 @@ const nav = [
         <div class="flex flex-wrap gap-x-5 gap-y-1">
           <a href="/writing/" class="label transition-colors hover:text-accent">Writing</a>
           <a href="/post/" class="label transition-colors hover:text-accent">Archive</a>
+          <a href="/newsletter/" class="label transition-colors hover:text-accent">Newsletter</a>
           <a href="https://speaking.mattstratton.com" rel="noopener" class="label transition-colors hover:text-accent">Speaking</a>
           <a href="https://github.com/mattstratton" rel="noopener" class="label transition-colors hover:text-accent">GitHub</a>
           <a href="https://www.linkedin.com/in/mattstratton" rel="noopener" class="label transition-colors hover:text-accent">LinkedIn</a>

--- a/src/lib/buttondown.ts
+++ b/src/lib/buttondown.ts
@@ -1,0 +1,87 @@
+import type { Loader } from 'astro/loaders';
+import { marked } from 'marked';
+
+// Astro content-layer loader for the newsletter archive. At build time it pulls
+// sent issues from the Buttondown API and exposes them as a `newsletter`
+// collection. The API key is read from the environment (BUTTONDOWN_API_KEY,
+// set as a Netlify env var + a local .env) — never committed. If the key is
+// missing or the API errors, the archive builds empty rather than failing the
+// build, so the site (and contributors without the key) still build fine.
+
+// Long-standing v1 base. If Buttondown moves it to api.buttondown.com, override
+// with BUTTONDOWN_API_BASE.
+const API_BASE =
+  import.meta.env.BUTTONDOWN_API_BASE ?? process.env.BUTTONDOWN_API_BASE ?? 'https://api.buttondown.email/v1';
+
+// Statuses that represent a publicly-archivable, already-delivered issue.
+const PUBLISHED = new Set(['sent', 'imported']);
+
+interface ButtondownEmail {
+  id: string;
+  subject?: string;
+  body?: string;
+  slug?: string;
+  publish_date?: string;
+  status?: string;
+  email_type?: string;
+}
+
+function excerptFrom(html: string, max = 200): string {
+  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+}
+
+export function buttondownLoader(): Loader {
+  return {
+    name: 'buttondown',
+    load: async ({ store, logger, parseData }) => {
+      store.clear();
+      const key = import.meta.env.BUTTONDOWN_API_KEY ?? process.env.BUTTONDOWN_API_KEY;
+      if (!key) {
+        logger.warn('BUTTONDOWN_API_KEY not set — newsletter archive will build empty.');
+        return;
+      }
+
+      const emails: ButtondownEmail[] = [];
+      let url: string | null = `${API_BASE}/emails?ordering=-publish_date`;
+      try {
+        while (url) {
+          const res: Response = await fetch(url, { headers: { Authorization: `Token ${key}` } });
+          if (!res.ok) {
+            logger.error(`Buttondown API ${res.status} ${res.statusText} — archive will build empty.`);
+            return;
+          }
+          const page = (await res.json()) as { results?: ButtondownEmail[]; next?: string | null };
+          emails.push(...(page.results ?? []));
+          url = page.next ?? null;
+        }
+      } catch (err) {
+        logger.error(`Buttondown fetch failed (${String(err)}) — archive will build empty.`);
+        return;
+      }
+
+      let count = 0;
+      for (const e of emails) {
+        if (!e.status || !PUBLISHED.has(e.status) || !e.slug) continue;
+        try {
+          const bodyHtml = marked.parse(e.body ?? '', { async: false }) as string;
+          const data = await parseData({
+            id: e.slug,
+            data: {
+              subject: e.subject ?? e.slug,
+              slug: e.slug,
+              publishDate: e.publish_date ?? new Date(0).toISOString(),
+              bodyHtml,
+              excerpt: excerptFrom(bodyHtml),
+            },
+          });
+          store.set({ id: e.slug, data });
+          count++;
+        } catch (err) {
+          logger.warn(`Skipped newsletter issue "${e.slug}" (${String(err)}).`);
+        }
+      }
+      logger.info(`Loaded ${count} newsletter issue(s) from Buttondown.`);
+    },
+  };
+}

--- a/src/lib/buttondown.ts
+++ b/src/lib/buttondown.ts
@@ -16,6 +16,10 @@ const API_BASE =
 // Statuses that represent a publicly-archivable, already-delivered issue.
 const PUBLISHED = new Set(['sent', 'imported']);
 
+// Buttondown can append " | <newsletter name>" to subjects. Strip it for clean
+// archive titles (the email subject is unaffected).
+const NAME_SUFFIX = / \| Uncommitted$/i;
+
 interface ButtondownEmail {
   id: string;
   subject?: string;
@@ -68,7 +72,7 @@ export function buttondownLoader(): Loader {
           const data = await parseData({
             id: e.slug,
             data: {
-              subject: e.subject ?? e.slug,
+              subject: (e.subject ?? e.slug).replace(NAME_SUFFIX, ''),
               slug: e.slug,
               publishDate: e.publish_date ?? new Date(0).toISOString(),
               bodyHtml,

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -1,4 +1,5 @@
 import type { CollectionEntry } from 'astro:content';
+import { externalFieldGuide } from '../data/field-guide';
 
 // The 4-part field-guide arc (matty-writing-plan.md). Order + labels drive the
 // grouped /writing index.
@@ -25,5 +26,37 @@ export function groupByPart(entries: CollectionEntry<'writing'>[]) {
     entries: entries.filter((e) => e.data.part === p.key),
   })).filter((g) => g.entries.length > 0);
   const ungrouped = entries.filter((e) => !e.data.part);
+  return { groups, ungrouped };
+}
+
+/** A field-guide entry, whether a native post (on-site) or an external link. */
+export interface GuideItem {
+  title: string;
+  description: string;
+  href: string;
+  external: boolean;
+}
+
+/**
+ * The full field guide: native writing posts + external tigerdata.com links
+ * (src/data/field-guide.ts), merged and grouped by the 4-part arc. Native posts
+ * lead each part; external links follow. Parts with no items are dropped.
+ */
+export function buildFieldGuide(native: CollectionEntry<'writing'>[]) {
+  const pub = publishedWriting(native);
+  const groups = PARTS.map((p) => {
+    const nat: GuideItem[] = pub
+      .filter((e) => e.data.part === p.key)
+      .map((e) => ({ title: e.data.title, description: e.data.description, href: `/writing/${e.id}/`, external: false }));
+    const ext: GuideItem[] = externalFieldGuide
+      .filter((l) => l.part === p.key)
+      .map((l) => ({ title: l.title, description: l.description, href: l.url, external: true }));
+    return { key: p.key, label: p.label, blurb: p.blurb, items: [...nat, ...ext] };
+  }).filter((g) => g.items.length > 0);
+
+  const ungrouped: GuideItem[] = pub
+    .filter((e) => !e.data.part)
+    .map((e) => ({ title: e.data.title, description: e.data.description, href: `/writing/${e.id}/`, external: false }));
+
   return { groups, ungrouped };
 }

--- a/src/pages/newsletter/[slug].astro
+++ b/src/pages/newsletter/[slug].astro
@@ -1,0 +1,39 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import Newsletter from '../../components/Newsletter.astro';
+
+export async function getStaticPaths() {
+  const issues = await getCollection('newsletter');
+  return issues.map((issue) => ({ params: { slug: issue.id }, props: { issue } }));
+}
+
+const { issue } = Astro.props;
+const d = issue.data;
+const date = d.publishDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+---
+
+<Base
+  title={`${d.subject} · Matty Stratton`}
+  description={d.excerpt}
+  type="article"
+  publishedTime={d.publishDate.toISOString()}
+>
+  <article class="mx-auto max-w-2xl">
+    <header class="border-b-2 border-ink pb-6">
+      <p class="label"><a href="/newsletter/" class="hover:text-accent">Newsletter</a></p>
+      <h1 class="mt-3 font-display text-4xl font-bold leading-tight tracking-tight text-balance sm:text-5xl">
+        {d.subject}
+      </h1>
+      <p class="label mt-4 normal-case tracking-normal">
+        <time datetime={d.publishDate.toISOString()}>{date}</time>
+      </p>
+    </header>
+
+    <div class="prose prose-lg mt-8 max-w-none" set:html={d.bodyHtml}></div>
+  </article>
+
+  <div class="mx-auto max-w-2xl">
+    <Newsletter />
+  </div>
+</Base>

--- a/src/pages/newsletter/confirmed.astro
+++ b/src/pages/newsletter/confirmed.astro
@@ -1,0 +1,21 @@
+---
+import Base from '../../layouts/Base.astro';
+---
+
+<Base
+  title="You're in · Uncommitted"
+  description="You're subscribed to Uncommitted."
+>
+  <section class="mx-auto max-w-xl py-16 text-center">
+    <p class="label">Uncommitted</p>
+    <h1 class="mt-4 font-display text-4xl font-bold tracking-tight sm:text-5xl">You're in.</h1>
+    <p class="mt-6 text-lg leading-relaxed text-ink-soft">
+      Confirmed. You'll get Uncommitted roughly monthly, whenever something worth reading ships. No filler
+      in between. In the meantime, there's plenty in the archive.
+    </p>
+    <div class="mt-8 flex flex-wrap justify-center gap-3">
+      <a href="/writing/" class="rounded-full bg-ink px-5 py-2.5 text-sm font-medium text-paper transition hover:bg-accent">Read the writing</a>
+      <a href="/newsletter/" class="rounded-full border border-ink px-5 py-2.5 text-sm font-medium transition hover:border-accent hover:text-accent">Past issues</a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -17,11 +17,11 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
   <section class="border-b-2 border-ink pb-8">
     <p class="label">Newsletter</p>
     <h1 class="mt-4 font-display text-5xl font-semibold leading-[0.95] tracking-tight text-balance">
-      The dispatch
+      Uncommitted
     </h1>
     <p class="mt-6 max-w-2xl text-lg leading-relaxed text-ink-soft">
-      New writing on Postgres internals and performance, sent when something worth reading ships. Plus a
-      couple of things from the week that are worth your time. No fixed schedule, no filler.
+      Roughly once a month, when something worth reading ships: new writing on Postgres internals and
+      performance, plus a couple of things worth your time. No filler.
     </p>
   </section>
 

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -1,0 +1,46 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import Newsletter from '../../components/Newsletter.astro';
+
+const issues = (await getCollection('newsletter')).sort(
+  (a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime(),
+);
+const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+---
+
+<Base
+  title="Newsletter · Matty Stratton"
+  description="Matty Stratton's newsletter: new posts on Postgres internals and performance, plus the occasional find worth knowing about."
+  image="/og/newsletter.png"
+>
+  <section class="border-b-2 border-ink pb-8">
+    <p class="label">Newsletter</p>
+    <h1 class="mt-4 font-display text-5xl font-semibold leading-[0.95] tracking-tight text-balance">
+      The dispatch
+    </h1>
+    <p class="mt-6 max-w-2xl text-lg leading-relaxed text-ink-soft">
+      New writing on Postgres internals and performance, sent when something worth reading ships. Plus a
+      couple of things from the week that are worth your time. No fixed schedule, no filler.
+    </p>
+  </section>
+
+  <Newsletter />
+
+  {issues.length > 0 && (
+    <section class="mt-14">
+      <h2 class="font-display text-2xl font-semibold">Past issues</h2>
+      <ul class="mt-4">
+        {issues.map((issue) => (
+          <li>
+            <a href={`/newsletter/${issue.id}/`} class="group block border-b border-rule py-4 transition-colors hover:bg-panel">
+              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{issue.data.subject}</h3>
+              {issue.data.excerpt && <p class="mt-1 text-ink-soft">{issue.data.excerpt}</p>}
+              <p class="label mt-1 normal-case tracking-normal">{fmt(issue.data.publishDate)}</p>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+</Base>

--- a/src/pages/newsletter/rss.xml.ts
+++ b/src/pages/newsletter/rss.xml.ts
@@ -1,0 +1,20 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async (context) => {
+  const issues = (await getCollection('newsletter')).sort(
+    (a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime(),
+  );
+  return rss({
+    title: 'Matty Stratton — Newsletter',
+    description: 'Postgres internals, performance, and the occasional find worth knowing about.',
+    site: context.site ?? 'https://www.mattstratton.com',
+    items: issues.map((issue) => ({
+      title: issue.data.subject,
+      description: issue.data.excerpt,
+      pubDate: issue.data.publishDate,
+      link: `/newsletter/${issue.id}/`,
+    })),
+  });
+};

--- a/src/pages/newsletter/thanks.astro
+++ b/src/pages/newsletter/thanks.astro
@@ -1,0 +1,21 @@
+---
+import Base from '../../layouts/Base.astro';
+---
+
+<Base
+  title="Almost there · Uncommitted"
+  description="Check your email to confirm your subscription to Uncommitted."
+>
+  <section class="mx-auto max-w-xl py-16 text-center">
+    <p class="label">Uncommitted</p>
+    <h1 class="mt-4 font-display text-4xl font-bold tracking-tight sm:text-5xl">Almost there.</h1>
+    <p class="mt-6 text-lg leading-relaxed text-ink-soft">
+      Check your inbox and click the confirmation link to finish subscribing. If it's not there in a
+      minute, peek in spam — and maybe drag it out, so the actual issues land where you'll see them.
+    </p>
+    <div class="mt-8 flex flex-wrap justify-center gap-3">
+      <a href="/writing/" class="rounded-full bg-ink px-5 py-2.5 text-sm font-medium text-paper transition hover:bg-accent">Read the writing</a>
+      <a href="/" class="rounded-full border border-ink px-5 py-2.5 text-sm font-medium transition hover:border-accent hover:text-accent">Back home</a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/og/[page].png.ts
+++ b/src/pages/og/[page].png.ts
@@ -24,6 +24,11 @@ export async function getStaticPaths() {
       subtitle: `${postCount.toLocaleString()} posts of personal writing, going back to 2001.`,
       badge: 'ARCHIVE',
     },
+    newsletter: {
+      title: 'The dispatch',
+      subtitle: 'New writing on Postgres internals and performance, sent when it ships.',
+      badge: 'NEWSLETTER',
+    },
     default: {
       title: 'Matty Stratton',
       subtitle: 'Postgres, performance, and 25 years of writing.',

--- a/src/pages/og/[page].png.ts
+++ b/src/pages/og/[page].png.ts
@@ -25,8 +25,8 @@ export async function getStaticPaths() {
       badge: 'ARCHIVE',
     },
     newsletter: {
-      title: 'The dispatch',
-      subtitle: 'New writing on Postgres internals and performance, sent when it ships.',
+      title: 'Uncommitted',
+      subtitle: 'Monthly dispatches on Postgres internals and performance.',
       badge: 'NEWSLETTER',
     },
     default: {

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -2,12 +2,9 @@
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
 import Newsletter from '../../components/Newsletter.astro';
-import { publishedWriting, groupByPart } from '../../lib/writing';
+import { buildFieldGuide, type GuideItem } from '../../lib/writing';
 
-const entries = publishedWriting(await getCollection('writing'));
-const { groups, ungrouped } = groupByPart(entries);
-
-const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+const { groups, ungrouped } = buildFieldGuide(await getCollection('writing'));
 ---
 
 <Base
@@ -23,24 +20,26 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
     <p class="mt-6 max-w-2xl text-lg leading-relaxed text-ink-soft">
       An evergreen reference on Postgres internals and the tradeoffs nobody warns you about. Read it
       start to finish as an onboarding path, or jump straight to the symptom you’re fighting right now.
+      Some pieces live here; others are on tigerdata.com, linked below.
     </p>
   </section>
-
-  {entries.length === 0 && (
-    <p class="mt-10 text-ink-soft">New posts are on the way. Subscribe below to get them when they ship.</p>
-  )}
 
   {groups.map((group) => (
     <section class="mt-12">
       <h2 class="font-display text-2xl font-semibold">{group.label}</h2>
       <p class="mt-1 text-ink-soft">{group.blurb}</p>
       <ul class="mt-4">
-        {group.entries.map((e) => (
+        {group.items.map((item: GuideItem) => (
           <li>
-            <a href={`/writing/${e.id}/`} class="group block border-b border-rule py-4 transition-colors hover:bg-panel">
-              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{e.data.title}</h3>
-              <p class="mt-1 text-ink-soft">{e.data.description}</p>
-              <p class="label mt-1 normal-case tracking-normal">{fmt(e.data.pubDate)}</p>
+            <a
+              href={item.href}
+              rel={item.external ? 'noopener' : undefined}
+              class="group block border-b border-rule py-4 transition-colors hover:bg-panel"
+            >
+              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">
+                {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
+              </h3>
+              <p class="mt-1 text-ink-soft">{item.description}</p>
             </a>
           </li>
         ))}
@@ -50,14 +49,13 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
 
   {ungrouped.length > 0 && (
     <section class="mt-12">
-      {groups.length > 0 && <h2 class="font-display text-2xl font-semibold">More writing</h2>}
+      <h2 class="font-display text-2xl font-semibold">More writing</h2>
       <ul class="mt-4">
-        {ungrouped.map((e) => (
+        {ungrouped.map((item: GuideItem) => (
           <li>
-            <a href={`/writing/${e.id}/`} class="group block border-b border-rule py-4 transition-colors hover:bg-panel">
-              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{e.data.title}</h3>
-              <p class="mt-1 text-ink-soft">{e.data.description}</p>
-              <p class="label mt-1 normal-case tracking-normal">{fmt(e.data.pubDate)}</p>
+            <a href={item.href} class="group block border-b border-rule py-4 transition-colors hover:bg-panel">
+              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{item.title}</h3>
+              <p class="mt-1 text-ink-soft">{item.description}</p>
             </a>
           </li>
         ))}


### PR DESCRIPTION
Part of #16. Builds the newsletter as native site pages (the Astro-rendered option we chose) rather than Buttondown's hosted archive, so it matches the site's design and lives on mattstratton.com.

## What's built
- **`src/lib/buttondown.ts`** — an Astro content-layer loader that fetches sent issues from the Buttondown API at build time, converts each body to HTML, and exposes a `newsletter` collection. Reads `BUTTONDOWN_API_KEY` from the environment (never committed). **Fails safe**: builds an empty archive (no build failure) if the key is missing or the API errors, and skips any single malformed issue.
- **Pages**: `/newsletter/` (signup + past issues), `/newsletter/<slug>/` per issue, `/newsletter/rss.xml`, and an OG card.
- Footer "Newsletter" link; `/page/newsletter/` redirect now points at `/newsletter/`.
- `.env` gitignored; env vars documented in `CLAUDE.md`.

## Config still needed to go live (no code, just settings)
1. **`buttondownUser`** in `src/data/home.ts` → flips the signup form from placeholder to live. (I'll set this once you give me the username.)
2. **`BUTTONDOWN_API_KEY`** in Netlify env vars (+ a local `.env`) → populates the archive. You generate + set it; I never see it.
3. Optional: a Buttondown "email sent" webhook → a Netlify build hook, so the archive refreshes automatically on each send.

## Verify-against-live caveat
The loader is built to the documented Buttondown v1 API shape but hasn't run against a real key yet. Once the key + a test issue exist, we should do one build to confirm field names/body format/API base are right (flagged in the loader comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)