### PR TITLE
Per-issue newsletter OG cards + excerpt entity fix

### DIFF
--- a/src/lib/buttondown.ts
+++ b/src/lib/buttondown.ts
@@ -30,8 +30,23 @@ interface ButtondownEmail {
   email_type?: string;
 }
 
+// Decode the HTML entities that survive tag-stripping, so the plain-text excerpt
+// (used in OG cards, meta descriptions, RSS, and the index) reads correctly
+// instead of showing literal "&#39;" etc.
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&quot;/g, '"')
+    .replace(/&(?:apos|#39);/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
 function excerptFrom(html: string, max = 200): string {
-  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  const text = decodeEntities(html.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
   return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
 }
 

--- a/src/pages/newsletter/[slug].astro
+++ b/src/pages/newsletter/[slug].astro
@@ -18,6 +18,7 @@ const date = d.publishDate.toLocaleDateString('en-US', { year: 'numeric', month:
   description={d.excerpt}
   type="article"
   publishedTime={d.publishDate.toISOString()}
+  image={`/og/newsletter/${issue.id}.png`}
 >
   <article class="mx-auto max-w-2xl">
     <header class="border-b-2 border-ink pb-6">

--- a/src/pages/og/newsletter/[slug].png.ts
+++ b/src/pages/og/newsletter/[slug].png.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { renderOgCard } from '../../../lib/og-card';
+
+// Per-issue OG cards for the newsletter archive (low volume, like writing posts —
+// worth a bespoke card each).
+export async function getStaticPaths() {
+  const issues = await getCollection('newsletter');
+  return issues.map((issue) => ({
+    params: { slug: issue.id },
+    props: { title: issue.data.subject, subtitle: issue.data.excerpt },
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { title, subtitle } = props as { title: string; subtitle: string };
+  const png = await renderOgCard({ title, subtitle, badge: 'NEWSLETTER' });
+  return new Response(new Uint8Array(png), {
+    headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=31536000, immutable' },
+  });
+};


### PR DESCRIPTION
Each newsletter issue now gets its own bespoke OG card, same as writing posts.

- **`src/pages/og/newsletter/[slug].png.ts`** — renders a per-issue card (title = subject, `NEWSLETTER` badge, excerpt subtitle), wired into the issue page's `og:image`.
- **Bug fix:** the plain-text excerpt is derived from rendered HTML, which carries entities (e.g. `&#39;` for apostrophes). The browser decodes those on the page, but satori (OG cards) and `<meta>` tags don't — so the card subtitle showed literal `don&#39;t`. Now we decode entities when building the excerpt, so cards/meta/RSS read `don't` correctly.

## Verified
Built against the live first issue: `/og/newsletter/<slug>.png` (1200×630) generates, the issue page references it, and the subtitle renders clean apostrophes.

After this, newsletter issues are the last page type to get bespoke cards — every meaningful page now has one (legacy archive posts still intentionally share the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)