### PR TITLE
Generalize /writing/ into a topic-browsable home for all current writing

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,9 +3,11 @@ import { glob } from 'astro/loaders';
 import { buttondownLoader } from './lib/buttondown';
 import { liftosaurLoader } from './lib/liftosaur';
 
-// The evergreen Postgres "field guide" authored on mattstratton.com going
-// forward. Separate from the legacy `posts` archive (added in the post-migration
-// phase): clean /writing/<slug> URLs, required description, evergreen metadata.
+// The living home for all of Matt's current writing on mattstratton.com — not
+// just Postgres. Separate from the legacy `posts` archive (added in the
+// post-migration phase, frozen at 2001–2020): clean /writing/<slug> URLs,
+// required description, evergreen metadata. `topics` is the universal tag
+// mechanism; `part` below is a special-cased curated arc, not the whole story.
 const writing = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/writing' }),
   schema: z.object({
@@ -13,8 +15,9 @@ const writing = defineCollection({
     description: z.string(),
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
-    // The 4-part arc from matty-writing-plan.md. Optional so standalone pieces
-    // can exist outside the guide structure.
+    // The curated 4-part Postgres arc (mechanics -> limits -> traps -> decision).
+    // Optional and Postgres-specific — most entries won't set this; everything
+    // else is tagged via `topics` instead.
     part: z.enum(['mechanics', 'limits', 'traps', 'decision']).optional(),
     topics: z.array(z.string()).default([]),
     draft: z.boolean().default(false),

--- a/src/layouts/WritingLayout.astro
+++ b/src/layouts/WritingLayout.astro
@@ -2,6 +2,7 @@
 import Base from './Base.astro';
 import Newsletter from '../components/Newsletter.astro';
 import { PARTS } from '../lib/writing';
+import { slugify } from '../lib/taxonomy';
 import type { CollectionEntry } from 'astro:content';
 
 interface Props {
@@ -47,7 +48,7 @@ const updated = d.updatedDate?.toLocaleDateString('en-US', { year: 'numeric', mo
     {d.topics.length > 0 && (
       <div class="mt-10 flex flex-wrap gap-2 border-t border-rule pt-6">
         {d.topics.map((t) => (
-          <span class="rounded-full bg-ink/5 px-3 py-1 text-sm ring-1 ring-rule">{t}</span>
+          <a href={`/writing/tags/${slugify(t)}/`} class="rounded-full bg-ink/5 px-3 py-1 text-sm ring-1 ring-rule transition hover:ring-accent">{t}</a>
         ))}
       </div>
     )}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,38 +1,20 @@
 import type { CollectionEntry } from 'astro:content';
+import { collectTaxonomy as collectTaxonomyGeneric, entriesForTerm, slugify } from './taxonomy';
 
-/** Hugo-compatible urlize: lowercase, drop apostrophes, non-alnum → hyphen. */
-export function slugify(s: string): string {
-  return s
-    .toLowerCase()
-    .trim()
-    .replace(/['']/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
+export { slugify };
+export type { TaxoTerm } from './taxonomy';
 
 /** All legacy posts, newest first. */
 export function sortedPosts(posts: CollectionEntry<'posts'>[]) {
   return [...posts].sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 }
 
-export interface TaxoTerm { name: string; slug: string; count: number; }
-
 /** Build a slug→term registry for a taxonomy field, with post counts. */
 export function collectTaxonomy(
   posts: CollectionEntry<'posts'>[],
   field: 'categories' | 'tags',
-): TaxoTerm[] {
-  const bySlug = new Map<string, TaxoTerm>();
-  for (const p of posts) {
-    for (const name of p.data[field]) {
-      const slug = slugify(name);
-      if (!slug) continue;
-      const term = bySlug.get(slug);
-      if (term) term.count++;
-      else bySlug.set(slug, { name, slug, count: 1 });
-    }
-  }
-  return [...bySlug.values()].sort((a, b) => a.name.localeCompare(b.name));
+) {
+  return collectTaxonomyGeneric(posts, (p) => p.data[field]);
 }
 
 /** Posts whose taxonomy field contains a term matching the given slug. */
@@ -41,7 +23,7 @@ export function postsForTerm(
   field: 'categories' | 'tags',
   slug: string,
 ) {
-  return sortedPosts(posts.filter((p) => p.data[field].some((n) => slugify(n) === slug)));
+  return sortedPosts(entriesForTerm(posts, (p) => p.data[field], slug));
 }
 
 /** Group posts by year (descending) for the archive listing. */

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -1,0 +1,31 @@
+/** Hugo-compatible urlize: lowercase, drop apostrophes, non-alnum → hyphen. */
+export function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .trim()
+    .replace(/['']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export interface TaxoTerm { name: string; slug: string; count: number; }
+
+/** Build a slug→term registry across entries, with counts, given a term extractor. */
+export function collectTaxonomy<T>(entries: T[], getTerms: (entry: T) => string[]): TaxoTerm[] {
+  const bySlug = new Map<string, TaxoTerm>();
+  for (const entry of entries) {
+    for (const name of getTerms(entry)) {
+      const slug = slugify(name);
+      if (!slug) continue;
+      const term = bySlug.get(slug);
+      if (term) term.count++;
+      else bySlug.set(slug, { name, slug, count: 1 });
+    }
+  }
+  return [...bySlug.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Entries whose terms contain one matching the given slug. */
+export function entriesForTerm<T>(entries: T[], getTerms: (entry: T) => string[], slug: string): T[] {
+  return entries.filter((entry) => getTerms(entry).some((n) => slugify(n) === slug));
+}

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -1,5 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import { externalFieldGuide } from '../data/field-guide';
+import { collectTaxonomy, entriesForTerm } from './taxonomy';
 
 // The 4-part field-guide arc (matty-writing-plan.md). Order + labels drive the
 // grouped /writing index.
@@ -27,6 +28,16 @@ export function groupByPart(entries: CollectionEntry<'writing'>[]) {
   })).filter((g) => g.entries.length > 0);
   const ungrouped = entries.filter((e) => !e.data.part);
   return { groups, ungrouped };
+}
+
+/** All distinct topics across published writing, alphabetical, with counts. */
+export function collectTopics(entries: CollectionEntry<'writing'>[]) {
+  return collectTaxonomy(publishedWriting(entries), (e) => e.data.topics);
+}
+
+/** Published writing entries tagged with the given topic slug, newest first (already sorted by publishedWriting). */
+export function writingForTopic(entries: CollectionEntry<'writing'>[], slug: string) {
+  return entriesForTerm(publishedWriting(entries), (e) => e.data.topics, slug);
 }
 
 /** A field-guide entry, whether a native post (on-site) or an external link. */

--- a/src/pages/og/[page].png.ts
+++ b/src/pages/og/[page].png.ts
@@ -16,9 +16,9 @@ export async function getStaticPaths() {
       badge: 'WRITING',
     },
     writing: {
-      title: 'Writing on Postgres',
-      subtitle: 'An evergreen field guide to Postgres internals and performance tradeoffs.',
-      badge: 'FIELD GUIDE',
+      title: 'Writing',
+      subtitle: 'Postgres internals, performance tradeoffs, and everything else — browsable by topic.',
+      badge: 'WRITING',
     },
     post: {
       title: 'The archive',

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -2,25 +2,27 @@
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
 import Newsletter from '../../components/Newsletter.astro';
-import { buildFieldGuide, type GuideItem } from '../../lib/writing';
+import { buildFieldGuide, collectTopics, type GuideItem } from '../../lib/writing';
 
-const { groups, ungrouped } = buildFieldGuide(await getCollection('writing'));
+const writingEntries = await getCollection('writing');
+const { groups, ungrouped } = buildFieldGuide(writingEntries);
+const topics = collectTopics(writingEntries);
 ---
 
 <Base
   title="Writing · Matty Stratton"
-  description="An evergreen field guide to Postgres internals, performance limits, and the architecture decisions that follow."
+  description="Everything Matt writes, browsable by topic — a curated Postgres field guide, plus everything else."
   image="/og/writing.png"
 >
   <section class="border-b-2 border-ink pb-8">
-    <p class="label">Field guide</p>
+    <p class="label">Writing</p>
     <h1 class="mt-4 font-display text-5xl font-semibold leading-[0.95] tracking-tight text-balance">
-      Writing on Postgres
+      Writing
     </h1>
     <p class="mt-6 max-w-2xl text-lg leading-relaxed text-ink-soft">
-      An evergreen reference on Postgres internals and the tradeoffs nobody warns you about. Read it
-      start to finish as an onboarding path, or jump straight to the symptom you’re fighting right now.
-      Some pieces live here; others are on tigerdata.com, linked below.
+      Everything I write, browsable by topic. The Postgres field guide below is a curated,
+      start-to-finish path through internals and performance tradeoffs — some pieces live here,
+      others are on tigerdata.com, linked below. For everything else, browse by topic.
     </p>
   </section>
 
@@ -60,6 +62,24 @@ const { groups, ungrouped } = buildFieldGuide(await getCollection('writing'));
           </li>
         ))}
       </ul>
+    </section>
+  )}
+
+  {topics.length > 0 && (
+    <section class="mt-12 border-t-2 border-ink pt-8">
+      <p class="label">Browse</p>
+      <h2 class="mt-2 font-display text-2xl font-semibold">By topic</h2>
+      <p class="mt-1 text-ink-soft">Postgres and everything else, organized by tag.</p>
+      <ul class="mt-4 flex flex-wrap gap-2">
+        {topics.map((t) => (
+          <li>
+            <a href={`/writing/tags/${t.slug}/`} class="inline-flex items-center gap-1.5 rounded-full bg-ink/5 px-3 py-1 text-sm ring-1 ring-rule transition hover:ring-accent">
+              {t.name}<span class="label normal-case tracking-normal !text-[0.62rem]">{t.count}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+      <p class="mt-4"><a href="/writing/tags/" class="label transition-colors hover:text-accent">All topics →</a></p>
     </section>
   )}
 

--- a/src/pages/writing/tags/[slug].astro
+++ b/src/pages/writing/tags/[slug].astro
@@ -1,0 +1,32 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../../layouts/Base.astro';
+import { collectTopics, writingForTopic } from '../../../lib/writing';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('writing');
+  return collectTopics(entries).map((term) => ({
+    params: { slug: term.slug },
+    props: { term, items: writingForTopic(entries, term.slug) },
+  }));
+}
+
+const { term, items } = Astro.props;
+const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+---
+
+<Base title={`#${term.name} · Writing · Matty Stratton`} description={`Writing tagged ${term.name}.`}>
+  <section class="border-b-2 border-ink pb-8">
+    <p class="label"><a href="/writing/tags/" class="hover:text-accent">Topics</a></p>
+    <h1 class="mt-4 font-display text-5xl font-semibold tracking-tight">{term.name}</h1>
+    <p class="label mt-3 normal-case tracking-normal">{items.length} posts</p>
+  </section>
+  <ul class="mt-6">
+    {items.map((e) => (
+      <li class="flex gap-4 border-b border-rule py-2.5">
+        <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(e.data.pubDate)}</span>
+        <a href={`/writing/${e.id}/`} class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline">{e.data.title}</a>
+      </li>
+    ))}
+  </ul>
+</Base>

--- a/src/pages/writing/tags/index.astro
+++ b/src/pages/writing/tags/index.astro
@@ -1,0 +1,23 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../../layouts/Base.astro';
+import { collectTopics } from '../../../lib/writing';
+
+const topics = collectTopics(await getCollection('writing'));
+---
+
+<Base title="Topics · Writing · Matty Stratton" description="Browse writing by topic.">
+  <section class="border-b-2 border-ink pb-8">
+    <p class="label"><a href="/writing/" class="hover:text-accent">Writing</a></p>
+    <h1 class="mt-4 font-display text-5xl font-semibold tracking-tight">Topics</h1>
+  </section>
+  <ul class="mt-8 flex flex-wrap gap-2">
+    {topics.map((t) => (
+      <li>
+        <a href={`/writing/tags/${t.slug}/`} class="inline-flex items-center gap-1.5 rounded-full bg-ink/5 px-3 py-1 text-sm ring-1 ring-rule transition hover:ring-accent">
+          {t.name}<span class="label normal-case tracking-normal !text-[0.62rem]">{t.count}</span>
+        </a>
+      </li>
+    ))}
+  </ul>
+</Base>


### PR DESCRIPTION
## Summary
- The `/writing/` section was scoped exclusively to Postgres content per an old TigerData-influenced planning doc (`matty-writing-plan.md`), which left no home on the site for general writing.
- `part` (the 4-value Postgres arc: mechanics/limits/traps/decision) stays reserved for the curated field-guide narrative, unchanged. `topics: string[]` becomes the universal tag mechanism for everything else.
- New `/writing/tags/` + `/writing/tags/[slug]/` pages mirror the existing legacy-archive `/tags/` pattern (same chip styling, same static-generation approach), built on a newly-extracted generic `src/lib/taxonomy.ts` so the legacy `/tags/`/`/categories/` pages are untouched (`src/lib/posts.ts` now delegates to it with identical behavior).
- `/writing/` index gets a new "Browse by topic" section alongside the existing Field Guide; individual post pages now link their topic chips instead of showing them as inert spans.
- Light copy pass softening Postgres-exclusive framing on the `/writing/` hero and its OG card.

This is Part 1 of a larger plan to consolidate the mattstratton.com stack and revive a general blog fed partly by dev.to cross-posts — see `/Users/mattstratton/.claude/plans/i-have-a-few-atomic-quill.md` for full context. This PR is self-contained and doesn't depend on the later monorepo-merge or cross-posting parts.

## Test plan
- [x] `npm run build` succeeds, `/writing/tags/index.html` generates correctly with zero published writing entries (graceful empty state)
- [x] `npm test` — all 42 existing tests pass unchanged
- [x] Verified end-to-end with a temporary throwaway writing entry (removed before commit): `/writing/` shows the new topic chip, `/writing/tags/` lists it, `/writing/tags/<slug>/` returns 200 and lists the post, and the post page's topic chip links correctly
- [x] Confirmed `/tags/`, `/tags/<slug>/`, `/categories/`, `/categories/<slug>/` (legacy archive) return 200 and are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)