### PR TITLE
Restore DevRel series grouping on dev.to + flag posts for crosspost

### DIFF
--- a/mattstratton-dev-to/posts/coding-agents-are-actually-good-at-this-one-thing-5dej.md
+++ b/mattstratton-dev-to/posts/coding-agents-are-actually-good-at-this-one-thing-5dej.md
@@ -7,6 +7,7 @@ canonical_url: 'https://dev.to/mattstratton/coding-agents-are-actually-good-at-t
 id: 3299129
 cover_image: 'https://dev-to-uploads.s3.amazonaws.com/uploads/articles/rxoya791llxf4y6v2c81.png'
 date: '2026-03-01T20:31:28Z'
+crosspost: true
 ---
 The discourse around AI coding tools tends to collapse into two camps: people who think they're going to replace developers, and people dunking on "vibe coding" demos that fall apart the moment you look at them sideways.
 

--- a/mattstratton-dev-to/posts/decouple-release-from-deploy.md
+++ b/mattstratton-dev-to/posts/decouple-release-from-deploy.md
@@ -10,6 +10,7 @@ tags:
 cover_image: ./assets/decouple-release-from-deploy-cover.png
 id: 4061454
 date: '2026-07-03T15:43:16Z'
+crosspost: true
 ---
 Picture a pipeline that looks pretty reasonable on paper. An agent opens pull requests. CI gates the merge to main: lint, tests, build, all green or it doesn't land. A scheduled job periodically promotes whatever's sitting in staging straight to production. No individual approval per feature. Just a batch cutover on a timer.
 

--- a/mattstratton-dev-to/posts/dont-fear-the-cfp-3mb1.md
+++ b/mattstratton-dev-to/posts/dont-fear-the-cfp-3mb1.md
@@ -7,6 +7,7 @@ canonical_url: 'https://medium.com/@mattstratton/dont-fear-the-cfp-e8272910972b'
 id: 14959
 cover_image: 'https://thepracticaldev.s3.amazonaws.com/i/jf16mw214n6h8zpwnz12.png'
 date: '2017-12-22T16:24:31Z'
+crosspost: true
 ---
 
 _This post is based upon a talk I gave at_ [_DevOpsDays Detroit&nbsp;2015_](https://legacy.devopsdays.org/events/2015-detroit/proposals/how-to-train-yourself/)_._

--- a/mattstratton-dev-to/posts/finance-101-budgets-pls-and-the-language-of-money-3dp9.md
+++ b/mattstratton-dev-to/posts/finance-101-budgets-pls-and-the-language-of-money-3dp9.md
@@ -7,6 +7,7 @@ tags:
 canonical_url: 'https://dev.to/mattstratton/finance-101-budgets-pls-and-the-language-of-money-3dp9'
 id: 2969627
 cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fqg4giv7gqcufvzmejpgr.png'
+series: DevRel Guide to Business
 date: '2025-10-28T18:53:35Z'
 ---
 *This is Part 4 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*

--- a/mattstratton-dev-to/posts/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it-3p2j.md
+++ b/mattstratton-dev-to/posts/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it-3p2j.md
@@ -7,6 +7,7 @@ canonical_url: 'https://dev.to/mattstratton/hosting-a-participant-first-conferen
 id: 510449
 cover_image: 'https://dev-to-uploads.s3.amazonaws.com/i/fyljvgmlrvoeqhr5qyn8.png'
 date: '2020-11-09T16:34:38Z'
+crosspost: true
 ---
 Sept 1, 2020 was the 7th annual [DevOpsDays Chicago](https://devopsdays.org/chicago) conference. It was also the first time we did it virtually. It was super well-received, and a lot of folks have been asking me for details on our implementation.
 

--- a/mattstratton-dev-to/posts/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me-265j.md
+++ b/mattstratton-dev-to/posts/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me-265j.md
@@ -7,6 +7,7 @@ canonical_url: 'https://dev.to/mattstratton/hot-takes-myths-and-fake-news---why-
 id: 57270
 cover_image: 'https://thepracticaldev.s3.amazonaws.com/i/38h2hq4ti2m5uc5k79z4.png'
 date: '2018-10-26T18:37:34Z'
+crosspost: true
 ---
 *(Adapted from a talk I gave at [DevOpsDays Indianapolis](https://www.devopsdays.org/events/2018-indianapolis/program/matt-stratton/) and [DevOpsDays Riga](https://www.devopsdays.org/events/2018-riga/program/matty-stratton-ignite-1/))*
 

--- a/mattstratton-dev-to/posts/how-my-coworker-who-didnt-know-cd-shipped-to-production-3j6j.md
+++ b/mattstratton-dev-to/posts/how-my-coworker-who-didnt-know-cd-shipped-to-production-3j6j.md
@@ -7,6 +7,7 @@ canonical_url: 'https://dev.to/mattstratton/how-my-coworker-who-didnt-know-cd-sh
 id: 3542818
 cover_image: 'https://dev-to-uploads.s3.amazonaws.com/uploads/articles/huq5hzde2dcbh58cle1i.png'
 date: '2026-04-23T20:30:39Z'
+crosspost: true
 ---
 This morning, our Design Lead asked me how to get her terminal into the right folder.
 

--- a/mattstratton-dev-to/posts/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81.md
+++ b/mattstratton-dev-to/posts/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81.md
@@ -7,6 +7,7 @@ tags:
 canonical_url: 'https://dev.to/mattstratton/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81'
 id: 2969196
 cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fzyg785kv0b888acwdq7l.png'
+series: DevRel Guide to Business
 date: '2025-10-28T16:09:00Z'
 ---
 *This is Part 3 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*

--- a/mattstratton-dev-to/posts/my-brewfile-1pob.md
+++ b/mattstratton-dev-to/posts/my-brewfile-1pob.md
@@ -7,6 +7,7 @@ canonical_url: 'https://dev.to/mattstratton/my-brewfile-1pob'
 id: 327372
 cover_image: 'https://dev-to-uploads.s3.amazonaws.com/i/e2bcvnrx9shjhpqfy8l5.png'
 date: '2020-05-04T20:51:50Z'
+crosspost: true
 ---
 *Updated 06-24-2026*
 

--- a/mattstratton-dev-to/posts/product-101-your-secret-weapon-for-understanding-the-business-2m6j.md
+++ b/mattstratton-dev-to/posts/product-101-your-secret-weapon-for-understanding-the-business-2m6j.md
@@ -7,6 +7,7 @@ tags:
 canonical_url: 'https://dev.to/mattstratton/product-101-your-secret-weapon-for-understanding-the-business-2m6j'
 id: 2991428
 cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fyul3alsercwqflrzkk8m.png'
+series: DevRel Guide to Business
 date: '2025-11-04T14:58:55Z'
 ---
 *This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*

--- a/mattstratton-dev-to/posts/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj.md
+++ b/mattstratton-dev-to/posts/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj.md
@@ -7,6 +7,7 @@ tags:
 canonical_url: 'https://dev.to/mattstratton/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj'
 id: 2969633
 cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F4f21cxu3z6d0ypgju4pa.png'
+series: DevRel Guide to Business
 date: '2025-10-28T18:54:34Z'
 ---
 *This is Part 7 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*

--- a/mattstratton-dev-to/posts/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8.md
+++ b/mattstratton-dev-to/posts/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8.md
@@ -7,6 +7,7 @@ tags:
 canonical_url: 'https://dev.to/mattstratton/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8'
 id: 2968777
 cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fzjpxkzku5xlxg42qlq49.png'
+series: DevRel Guide to Business
 date: '2025-10-28T13:41:03Z'
 ---
 *This is Part 2 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*

--- a/mattstratton-dev-to/posts/the-five-love-languages-of-devops-a78.md
+++ b/mattstratton-dev-to/posts/the-five-love-languages-of-devops-a78.md
@@ -6,6 +6,7 @@ tags: long
 canonical_url: 'https://medium.com/@mattstratton/the-five-love-languages-of-devops-77606263c910'
 id: 11211
 date: '2017-10-31T18:35:20Z'
+crosspost: true
 ---
 
 _Based upon a talk I have given at several&nbsp;events._

--- a/mattstratton-dev-to/posts/the-monorepo-song-1fce.md
+++ b/mattstratton-dev-to/posts/the-monorepo-song-1fce.md
@@ -7,6 +7,7 @@ canonical_url: 'https://dev.to/mattstratton/the-monorepo-song-1fce'
 id: 251917
 cover_image: 'https://dev-to-uploads.s3.amazonaws.com/i/1gwecfd4ed3nf07pjlee.jpg'
 date: '2020-01-30T21:33:31Z'
+crosspost: true
 ---
 (apologies to The Simpsons)
 originally posted on the twitters at https://twitter.com/mattstratton/status/1222989536243920904


### PR DESCRIPTION
## Summary
- Adds \`series: DevRel Guide to Business\` to the 5 posts in the 7-part business-literacy series that are currently missing it on dev.to (\`sales-101\`, \`marketing-101\`, \`finance-101\`, \`product-101\`, \`putting-it-all-together\`) — confirmed via dev.to's public API that only 2 of 7 currently show the series grouping live (\`why-business-literacy-matters\` and \`product-led-growth\`, both with \`collection_id: 33884\`). Merging will trigger \`devto-publish\` and establish the grouping for all 7 for the first time via our tooling.
- Also carries Matt's \`crosspost: true\` flags added locally on several other posts, ahead of running them through the crosspost script.
- Note for review: two flagged posts (\`dont-fear-the-cfp-3mb1.md\`, \`the-five-love-languages-of-devops-a78.md\`) have \`canonical_url\` pointing to medium.com, not dev.to — the crosspost script's canonical-host guard will require \`--override-canonical\` on those two.

## Test plan
- [ ] After merge, confirm via dev.to's public API (\`GET /api/articles/<id>\`) that all 7 DevRel series posts now show a matching \`collection_id\`
- [ ] Confirm \`devto-publish\` run succeeds with no unexpected side effects on the other flagged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)