### PR TITLE
Fix: crosspost script was clobbering YAML quoting, breaking devto-publish

### DIFF
--- a/mattstratton-dev-to/posts/coding-agents-are-actually-good-at-this-one-thing-5dej.md
+++ b/mattstratton-dev-to/posts/coding-agents-are-actually-good-at-this-one-thing-5dej.md
@@ -3,10 +3,10 @@ title: Coding Agents Are Actually Good at This One Thing
 published: true
 description: Coding agents aren't magic. But for internal tooling? They've brought back the "just build the thing" era I've been missing since Microsoft Access.
 tags: webd
-canonical_url: https://www.mattstratton.com/writing/coding-agents-are-actually-good-at-this-one-thing/
+canonical_url: 'https://www.mattstratton.com/writing/coding-agents-are-actually-good-at-this-one-thing/'
 id: 3299129
-cover_image: https://dev-to-uploads.s3.amazonaws.com/uploads/articles/rxoya791llxf4y6v2c81.png
-date: 2026-03-01T20:31:28Z
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/uploads/articles/rxoya791llxf4y6v2c81.png'
+date: '2026-03-01T20:31:28Z'
 crosspost: true
 ---
 The discourse around AI coding tools tends to collapse into two camps: people who think they're going to replace developers, and people dunking on "vibe coding" demos that fall apart the moment you look at them sideways.

--- a/mattstratton-dev-to/posts/decouple-release-from-deploy.md
+++ b/mattstratton-dev-to/posts/decouple-release-from-deploy.md
@@ -1,7 +1,7 @@
 ---
 title: Your Agent Didn't Break Prod. Your Pipeline Did.
 published: true
-description: "'Merged' and 'live' are not the same event, and an agent that can merge to main doesn't change that. It just makes it obvious you never separated them."
+description: '''Merged'' and ''live'' are not the same event, and an agent that can merge to main doesn''t change that. It just makes it obvious you never separated them.'
 tags:
   - devops
   - ai
@@ -9,9 +9,9 @@ tags:
   - cicd
 cover_image: ./assets/decouple-release-from-deploy-cover.png
 id: 4061454
-date: 2026-07-03T15:43:16Z
+date: '2026-07-03T15:43:16Z'
 crosspost: true
-canonical_url: https://www.mattstratton.com/writing/decouple-release-from-deploy/
+canonical_url: 'https://www.mattstratton.com/writing/decouple-release-from-deploy/'
 ---
 Picture a pipeline that looks pretty reasonable on paper. An agent opens pull requests. CI gates the merge to main: lint, tests, build, all green or it doesn't land. A scheduled job periodically promotes whatever's sitting in staging straight to production. No individual approval per feature. Just a batch cutover on a timer.
 

--- a/mattstratton-dev-to/posts/dont-fear-the-cfp-3mb1.md
+++ b/mattstratton-dev-to/posts/dont-fear-the-cfp-3mb1.md
@@ -3,10 +3,10 @@ title: Don’t Fear the CFP
 published: true
 description: Deciding to submit a talk for consideration at an event can be a troubling thing — what if my idea isn’t good enough? Do I think big enough thoughts to share a stage with Thought Leaders? Why would anyone care what I have to?
 tags: publ
-canonical_url: https://www.mattstratton.com/writing/dont-fear-the-cfp/
+canonical_url: 'https://www.mattstratton.com/writing/dont-fear-the-cfp/'
 id: 14959
-cover_image: https://thepracticaldev.s3.amazonaws.com/i/jf16mw214n6h8zpwnz12.png
-date: 2017-12-22T16:24:31Z
+cover_image: 'https://thepracticaldev.s3.amazonaws.com/i/jf16mw214n6h8zpwnz12.png'
+date: '2017-12-22T16:24:31Z'
 crosspost: true
 ---
 

--- a/mattstratton-dev-to/posts/finance-101-budgets-pls-and-the-language-of-money-3dp9.md
+++ b/mattstratton-dev-to/posts/finance-101-budgets-pls-and-the-language-of-money-3dp9.md
@@ -1,15 +1,14 @@
 ---
-title: "Finance 101: Budgets, P&Ls, and the Language of Money"
+title: 'Finance 101: Budgets, P&Ls, and the Language of Money'
 published: true
-description: Want to defend your DevRel budget? Learn to speak finance. Understand P&Ls, CapEx vs OpEx, and why your CFO cares about things you've never thought about.
+description: 'Want to defend your DevRel budget? Learn to speak finance. Understand P&Ls, CapEx vs OpEx, and why your CFO cares about things you''ve never thought about.'
 tags:
   - devrel
-canonical_url: https://www.mattstratton.com/writing/finance-101-budgets-pls-and-the-language-of-money/
+canonical_url: 'https://www.mattstratton.com/writing/finance-101-budgets-pls-and-the-language-of-money/'
 id: 2969627
-cover_image: https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fqg4giv7gqcufvzmejpgr.png
+cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fqg4giv7gqcufvzmejpgr.png'
 series: DevRel Guide to Business
-date: 2025-10-28T18:53:35Z
-crosspost: true
+date: '2025-10-28T18:53:35Z'
 ---
 *This is Part 4 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
 

--- a/mattstratton-dev-to/posts/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it-3p2j.md
+++ b/mattstratton-dev-to/posts/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it-3p2j.md
@@ -1,12 +1,12 @@
 ---
 title: Hosting a Participant-First Conference in the Age of Corona - How To Do It
 published: true
-description: Sept 1, 2020 was the 7th annual DevOpsDays Chicago conference. It was also the first time we did it virtually. It was super well-received, and a lot of folks have been asking me for details on our implementation.
+description: 'Sept 1, 2020 was the 7th annual DevOpsDays Chicago conference. It was also the first time we did it virtually. It was super well-received, and a lot of folks have been asking me for details on our implementation.'
 tags: even
-canonical_url: https://www.mattstratton.com/writing/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it/
+canonical_url: 'https://www.mattstratton.com/writing/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it/'
 id: 510449
-cover_image: https://dev-to-uploads.s3.amazonaws.com/i/fyljvgmlrvoeqhr5qyn8.png
-date: 2020-11-09T16:34:38Z
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/i/fyljvgmlrvoeqhr5qyn8.png'
+date: '2020-11-09T16:34:38Z'
 crosspost: true
 ---
 Sept 1, 2020 was the 7th annual [DevOpsDays Chicago](https://devopsdays.org/chicago) conference. It was also the first time we did it virtually. It was super well-received, and a lot of folks have been asking me for details on our implementation.

--- a/mattstratton-dev-to/posts/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me-265j.md
+++ b/mattstratton-dev-to/posts/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me-265j.md
@@ -1,12 +1,12 @@
 ---
-title: Hot Takes, Myths, And Falsehoods - Why Everyone Is Wrong About DevOps (Except For Me)
+title: 'Hot Takes, Myths, And Falsehoods - Why Everyone Is Wrong About DevOps (Except For Me)'
 published: true
-description: Don't believe everything you read on the internet when it comes to DevOps. A lot of people think they know what they are talking about, but they really don't. I, on the other hand, know exactly what I'm talking about.
+description: 'Don''t believe everything you read on the internet when it comes to DevOps. A lot of people think they know what they are talking about, but they really don''t. I, on the other hand, know exactly what I''m talking about.'
 tags: devo
-canonical_url: https://www.mattstratton.com/writing/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me/
+canonical_url: 'https://www.mattstratton.com/writing/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me/'
 id: 57270
-cover_image: https://thepracticaldev.s3.amazonaws.com/i/38h2hq4ti2m5uc5k79z4.png
-date: 2018-10-26T18:37:34Z
+cover_image: 'https://thepracticaldev.s3.amazonaws.com/i/38h2hq4ti2m5uc5k79z4.png'
+date: '2018-10-26T18:37:34Z'
 crosspost: true
 ---
 *(Adapted from a talk I gave at [DevOpsDays Indianapolis](https://www.devopsdays.org/events/2018-indianapolis/program/matt-stratton/) and [DevOpsDays Riga](https://www.devopsdays.org/events/2018-riga/program/matty-stratton-ignite-1/))*

--- a/mattstratton-dev-to/posts/how-my-coworker-who-didnt-know-cd-shipped-to-production-3j6j.md
+++ b/mattstratton-dev-to/posts/how-my-coworker-who-didnt-know-cd-shipped-to-production-3j6j.md
@@ -3,10 +3,10 @@ title: How My Coworker Who Didn't Know 'cd' Shipped to Production
 published: true
 description: The agent isn't the hard part. The scaffolding around it is. Here's how we built ours so a non-engineer could ship to production safely.
 tags: webd
-canonical_url: https://www.mattstratton.com/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production/
+canonical_url: 'https://www.mattstratton.com/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production/'
 id: 3542818
-cover_image: https://dev-to-uploads.s3.amazonaws.com/uploads/articles/huq5hzde2dcbh58cle1i.png
-date: 2026-04-23T20:30:39Z
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/uploads/articles/huq5hzde2dcbh58cle1i.png'
+date: '2026-04-23T20:30:39Z'
 crosspost: true
 ---
 This morning, our Design Lead asked me how to get her terminal into the right folder.

--- a/mattstratton-dev-to/posts/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81.md
+++ b/mattstratton-dev-to/posts/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81.md
@@ -1,15 +1,14 @@
 ---
-title: "Marketing 101: Funnels, Campaigns, and What Marketing Actually Means"
+title: 'Marketing 101: Funnels, Campaigns, and What Marketing Actually Means'
 published: true
-description: DevRel isn't marketing, but you need to speak their language. Learn about funnels, MQLs, and campaigns...and why understanding marketing makes you better at DevRel.
+description: 'DevRel isn''t marketing, but you need to speak their language. Learn about funnels, MQLs, and campaigns...and why understanding marketing makes you better at DevRel.'
 tags:
   - devrel
-canonical_url: https://www.mattstratton.com/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/
+canonical_url: 'https://www.mattstratton.com/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/'
 id: 2969196
-cover_image: https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fzyg785kv0b888acwdq7l.png
+cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fzyg785kv0b888acwdq7l.png'
 series: DevRel Guide to Business
-date: 2025-10-28T16:09:00Z
-crosspost: true
+date: '2025-10-28T16:09:00Z'
 ---
 *This is Part 3 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
 

--- a/mattstratton-dev-to/posts/my-brewfile-1pob.md
+++ b/mattstratton-dev-to/posts/my-brewfile-1pob.md
@@ -1,12 +1,12 @@
 ---
 title: My Brewfile (Updated)
 published: true
-description: Did you know that Homebrew can install more than just packages? Here's an updated guided tour through my Brewfile to see how I set up applications, VS Code extensions, and more on my MacBook.
+description: 'Did you know that Homebrew can install more than just packages? Here''s an updated guided tour through my Brewfile to see how I set up applications, VS Code extensions, and more on my MacBook.'
 tags: home
-canonical_url: https://www.mattstratton.com/writing/my-brewfile-1pob/
+canonical_url: 'https://www.mattstratton.com/writing/my-brewfile-1pob/'
 id: 327372
-cover_image: https://dev-to-uploads.s3.amazonaws.com/i/e2bcvnrx9shjhpqfy8l5.png
-date: 2020-05-04T20:51:50Z
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/i/e2bcvnrx9shjhpqfy8l5.png'
+date: '2020-05-04T20:51:50Z'
 crosspost: true
 ---
 *Updated 06-24-2026*

--- a/mattstratton-dev-to/posts/product-101-your-secret-weapon-for-understanding-the-business-2m6j.md
+++ b/mattstratton-dev-to/posts/product-101-your-secret-weapon-for-understanding-the-business-2m6j.md
@@ -1,15 +1,14 @@
 ---
-title: "Product 101: Your Secret Weapon for Understanding the Business"
+title: 'Product 101: Your Secret Weapon for Understanding the Business'
 published: true
 description: Strategic product leaders sit at the intersection of everything. Learn why Product is DevRel's most valuable partnership—and your secret source of business intel.
 tags:
   - devrel
-canonical_url: https://www.mattstratton.com/writing/product-101-your-secret-weapon-for-understanding-the-business/
+canonical_url: 'https://www.mattstratton.com/writing/product-101-your-secret-weapon-for-understanding-the-business/'
 id: 2991428
-cover_image: https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fyul3alsercwqflrzkk8m.png
+cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fyul3alsercwqflrzkk8m.png'
 series: DevRel Guide to Business
-date: 2025-11-04T14:58:55Z
-crosspost: true
+date: '2025-11-04T14:58:55Z'
 ---
 *This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
 

--- a/mattstratton-dev-to/posts/product-led-growth-and-what-it-means-for-devrel-10mj.md
+++ b/mattstratton-dev-to/posts/product-led-growth-and-what-it-means-for-devrel-10mj.md
@@ -1,14 +1,13 @@
 ---
 title: Product-Led Growth and What It Means for DevRel
 published: true
-description: Product-Led Growth changes everything for DevRel. Learn how PLG works, why it matters for developer tools, and how DevRel becomes essential infrastructure.
+description: 'Product-Led Growth changes everything for DevRel. Learn how PLG works, why it matters for developer tools, and how DevRel becomes essential infrastructure.'
 tags: devr
-canonical_url: https://www.mattstratton.com/writing/product-led-growth-and-what-it-means-for-devrel/
+canonical_url: 'https://www.mattstratton.com/writing/product-led-growth-and-what-it-means-for-devrel/'
 id: 2969631
-cover_image: https://dev-to-uploads.s3.amazonaws.com/uploads/articles/o6sijn10fab2fuftqg2j.png
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/uploads/articles/o6sijn10fab2fuftqg2j.png'
 series: DevRel Guide to Business
-date: 2025-10-28T18:54:05Z
-crosspost: true
+date: '2025-10-28T18:54:05Z'
 ---
 *This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
 

--- a/mattstratton-dev-to/posts/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj.md
+++ b/mattstratton-dev-to/posts/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj.md
@@ -1,15 +1,14 @@
 ---
-title: "Putting It All Together: Speaking Business as a DevRel Professional"
+title: 'Putting It All Together: Speaking Business as a DevRel Professional'
 published: true
-description: You've learned sales, marketing, finance, and PLG. Now learn how to translate DevRel work into business language that resonates with every stakeholder in your company.
+description: 'You''ve learned sales, marketing, finance, and PLG. Now learn how to translate DevRel work into business language that resonates with every stakeholder in your company.'
 tags:
   - devrel
-canonical_url: https://www.mattstratton.com/writing/putting-it-all-together-speaking-business-as-a-devrel-professional/
+canonical_url: 'https://www.mattstratton.com/writing/putting-it-all-together-speaking-business-as-a-devrel-professional/'
 id: 2969633
-cover_image: https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F4f21cxu3z6d0ypgju4pa.png
+cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F4f21cxu3z6d0ypgju4pa.png'
 series: DevRel Guide to Business
-date: 2025-10-28T18:54:34Z
-crosspost: true
+date: '2025-10-28T18:54:34Z'
 ---
 *This is Part 7 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
 

--- a/mattstratton-dev-to/posts/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8.md
+++ b/mattstratton-dev-to/posts/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8.md
@@ -1,15 +1,14 @@
 ---
-title: "Sales 101: What Your Sales Team Does (And How DevRel Fits In)"
+title: 'Sales 101: What Your Sales Team Does (And How DevRel Fits In)'
 published: true
-description: Stop treating sales like the enemy. Learn what your sales team actually does, decode pipeline and ARR, and discover how DevRel impacts deals without selling out.
+description: 'Stop treating sales like the enemy. Learn what your sales team actually does, decode pipeline and ARR, and discover how DevRel impacts deals without selling out.'
 tags:
   - devrel
-canonical_url: https://www.mattstratton.com/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/
+canonical_url: 'https://www.mattstratton.com/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/'
 id: 2968777
-cover_image: https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fzjpxkzku5xlxg42qlq49.png
+cover_image: 'https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fzjpxkzku5xlxg42qlq49.png'
 series: DevRel Guide to Business
-date: 2025-10-28T13:41:03Z
-crosspost: true
+date: '2025-10-28T13:41:03Z'
 ---
 *This is Part 2 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
 

--- a/mattstratton-dev-to/posts/the-five-love-languages-of-devops-a78.md
+++ b/mattstratton-dev-to/posts/the-five-love-languages-of-devops-a78.md
@@ -1,11 +1,11 @@
 ---
 title: The Five Love Languages of DevOps
 published: true
-description: When we are working to bring about cultural change in our organization, it’s essential for us to understand that not everyone speaks the same “language of DevOps as we do.
+description: 'When we are working to bring about cultural change in our organization, it’s essential for us to understand that not everyone speaks the same “language of DevOps as we do.'
 tags: long
-canonical_url: https://www.mattstratton.com/writing/the-five-love-languages-of-devops/
+canonical_url: 'https://www.mattstratton.com/writing/the-five-love-languages-of-devops/'
 id: 11211
-date: 2017-10-31T18:35:20Z
+date: '2017-10-31T18:35:20Z'
 crosspost: true
 ---
 

--- a/mattstratton-dev-to/posts/the-monorepo-song-1fce.md
+++ b/mattstratton-dev-to/posts/the-monorepo-song-1fce.md
@@ -3,10 +3,10 @@ title: The Monorepo Song
 published: true
 description: Because a dev with root access is like a mule with a spinning wheel
 tags: humo
-canonical_url: https://www.mattstratton.com/writing/the-monorepo-song/
+canonical_url: 'https://www.mattstratton.com/writing/the-monorepo-song/'
 id: 251917
-cover_image: https://dev-to-uploads.s3.amazonaws.com/i/1gwecfd4ed3nf07pjlee.jpg
-date: 2020-01-30T21:33:31Z
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/i/1gwecfd4ed3nf07pjlee.jpg'
+date: '2020-01-30T21:33:31Z'
 crosspost: true
 ---
 (apologies to The Simpsons)

--- a/mattstratton-dev-to/posts/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1.md
+++ b/mattstratton-dev-to/posts/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1.md
@@ -1,14 +1,13 @@
 ---
 title: Why Business Literacy Matters for DevRel (And Why You Can't Skip This Step)
 published: true
-description: DevRel teams struggle to prove value because they lack business literacy. Learn why understanding sales, marketing, and finance is foundational to DevRel success.
+description: 'DevRel teams struggle to prove value because they lack business literacy. Learn why understanding sales, marketing, and finance is foundational to DevRel success.'
 tags: devr
-canonical_url: https://www.mattstratton.com/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/
+canonical_url: 'https://www.mattstratton.com/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/'
 id: 2966206
-cover_image: https://dev-to-uploads.s3.amazonaws.com/uploads/articles/558ps6yn849q6cvqoiyz.png
+cover_image: 'https://dev-to-uploads.s3.amazonaws.com/uploads/articles/558ps6yn849q6cvqoiyz.png'
 series: DevRel Guide to Business
-date: 2025-10-27T18:51:10Z
-crosspost: true
+date: '2025-10-27T18:51:10Z'
 ---
 I hear over and over again, "the business doesn't understand DevRel." I'm here to tell you that is backwards - the problem is that DevRel doesn't understand business.
 

--- a/scripts/crosspost-devto.test.ts
+++ b/scripts/crosspost-devto.test.ts
@@ -12,6 +12,7 @@ import {
   delinkEmbeds,
   checkCanonicalHost,
   buildWritingFrontmatter,
+  setCanonicalUrl,
 } from './crosspost-devto.ts';
 
 test('splitFrontmatter splits on first delimiter pair only', () => {
@@ -95,6 +96,22 @@ test('deriveImageFilename handles a relative local cover image', () => {
 
 test('deriveImageFilename falls back to a generated name for an opaque URL', () => {
   assert.equal(deriveImageFilename('https://example.com/no-extension-here', 3), 'image-3.png');
+});
+
+test('setCanonicalUrl replaces an existing canonical_url line in place, leaving every other line byte-for-byte untouched (regression: full YAML re-stringify used to drop quotes from date, which dev.to\'s Ruby YAML parser then rejects as an unquoted Time scalar)', () => {
+  const fmRaw = "title: The Monorepo Song\npublished: true\ntags:\n  - humo\ncanonical_url: 'https://dev.to/mattstratton/the-monorepo-song-1fce'\nid: 251917\ndate: '2020-01-30T21:33:31Z'";
+  const result = setCanonicalUrl(fmRaw, 'https://www.mattstratton.com/writing/the-monorepo-song/');
+  assert.match(result, /^canonical_url: 'https:\/\/www\.mattstratton\.com\/writing\/the-monorepo-song\/'$/m);
+  assert.match(result, /^date: '2020-01-30T21:33:31Z'$/m, 'date quoting must be preserved untouched');
+  assert.match(result, /^id: 251917$/m);
+  assert.equal(result.split('\n').length, fmRaw.split('\n').length, 'line count unchanged - only the one line was replaced');
+});
+
+test('setCanonicalUrl appends a new canonical_url line when none exists yet', () => {
+  const fmRaw = "title: zshrc tour\npublished: true\nid: 4043143";
+  const result = setCanonicalUrl(fmRaw, 'https://www.mattstratton.com/writing/zshrc-tour/');
+  assert.match(result, /^canonical_url: 'https:\/\/www\.mattstratton\.com\/writing\/zshrc-tour\/'$/m);
+  assert.match(result, /^id: 4043143$/m);
 });
 
 test('delinkEmbeds converts youtube and twitter Liquid tags to plain links', () => {

--- a/scripts/crosspost-devto.ts
+++ b/scripts/crosspost-devto.ts
@@ -122,6 +122,24 @@ export function delinkEmbeds(body: string): string {
     .replace(/\{%\s*twitter\s+(\d+)\s*%\}/g, '[View the original post](https://twitter.com/i/web/status/$1)');
 }
 
+/**
+ * Set (or insert) `canonical_url` in a raw YAML frontmatter block via targeted
+ * line replacement, WITHOUT parsing+re-stringifying the whole block. Round-tripping
+ * through `YAML.stringify` silently drops quotes from scalars like an ISO date
+ * (`date: '2020-01-30T21:33:31Z'` -> `date: 2020-01-30T21:33:31Z`) that don't need
+ * them under this library's own YAML 1.2 core schema — but dev.to's Ruby backend
+ * parses that unquoted scalar as a native Time object and its safe-loader rejects
+ * it (`Tried to load unspecified class: Time`, HTTP 422). Editing only the one
+ * line we actually mean to change avoids touching any other field's formatting.
+ */
+export function setCanonicalUrl(fmRaw: string, url: string): string {
+  const quoted = `canonical_url: '${url}'`;
+  if (/^canonical_url:.*$/m.test(fmRaw)) {
+    return fmRaw.replace(/^canonical_url:.*$/m, quoted);
+  }
+  return `${fmRaw.replace(/\n$/, '')}\n${quoted}`;
+}
+
 /** Refuse (unless overridden) if the post's existing canonical_url points anywhere
  *  other than dev.to itself — that means its true canonical predates dev.to (Medium,
  *  a tigerdata.com blog post, etc.) and deciding where canonical should point is a
@@ -280,8 +298,7 @@ async function main() {
   writeFileSync(targetPath, newFile, 'utf8');
 
   const mattstrattonUrl = `https://www.mattstratton.com/writing/${slug}/`;
-  const updatedSourceFm = { ...fm, canonical_url: mattstrattonUrl };
-  const updatedSource = `---\n${YAML.stringify(updatedSourceFm, { lineWidth: 0 }).trimEnd()}\n---\n${body}`;
+  const updatedSource = `---\n${setCanonicalUrl(fmRaw, mattstrattonUrl)}\n---\n${body}`;
   writeFileSync(sourcePath, updatedSource, 'utf8');
 
   console.log(`\nWrote ${relative(ROOT, targetPath)}`);


### PR DESCRIPTION
## Summary
The last \`devto-publish\` run ([logs](https://github.com/mattstratton/mattstratton-web/actions/runs/28677095027)) failed with HTTP 422 on all 13 posts whose \`canonical_url\` was being *changed* to a new value (posts setting it for the first time, like \`zshrc-tour\`, were unaffected).

**Root cause, confirmed by directly reproducing the exact failing API call and inspecting the real response body** (not guessed): \`{"error":"Tried to load unspecified class: Time","status":422}\`. The crosspost script rewrote each source file's frontmatter via a full \`YAML.stringify()\` round-trip, which silently drops quotes from scalars that don't need them under this library's own YAML 1.2 core schema — e.g. \`date: '2020-01-30T21:33:31Z'\` became \`date: 2020-01-30T21:33:31Z\`. dev.to's Ruby backend parses that now-unquoted scalar as a native \`Time\` object, and its safe YAML loader refuses to instantiate it.

**Fix**: \`setCanonicalUrl()\` does a targeted single-line replace/insert directly on the raw frontmatter text instead of parsing and re-serializing the whole block, so no other field's formatting is ever touched.

**Repair**: restored all 16 affected posts to their true pre-crosspost content (the two CRLF-line-ending files correctly normalized to LF first, matching what was actually done before crossposting them) and reapplied just the \`canonical_url\` change with the fixed logic. Verified every file's diff against its real original is exactly the one intended line — see commit message for the verification method.

## Test plan
- [x] Added regression tests for \`setCanonicalUrl\` (preserves surrounding quoting, both replace and insert cases) — 62/62 tests pass
- [x] \`npm run build\` succeeds
- [x] Every repaired file's diff against its pre-crosspost git history verified to be exactly one line (the canonical_url value)
- [ ] After merge: confirm \`devto-publish\` succeeds for all 16 posts this time, and spot-check a couple of live dev.to articles show the correct canonical link

🤖 Generated with [Claude Code](https://claude.com/claude-code)