### PR TITLE
Rewrite internal dev.to links to /writing/ across crossposted posts

### DIFF
--- a/src/content/writing/decouple-release-from-deploy.md
+++ b/src/content/writing/decouple-release-from-deploy.md
@@ -19,7 +19,7 @@ That pipeline will absolutely, eventually, wreck your week.
 
 Not because the agent did anything malicious. Because two very different questions got quietly collapsed into one gate: "did this pass CI" and "is this safe for a real person to see right now." Those have never been the same question, not for humans and not for robots. We just used to have enough friction in the deploy process that the gap between them rarely mattered.
 
-I've [written before](https://dev.to/mattstratton/how-my-coworker-who-didnt-know-cd-shipped-to-production-3j6j) about the scaffolding that lets a non-engineer safely drive a coding agent against a real codebase. Rules, skills, hooks. Three layers of paranoia built into the system instead of relying on any one person's vigilance on a random Friday. That post was about the merge gate: what stops garbage from landing on `main`.
+I've [written before](/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production/) about the scaffolding that lets a non-engineer safely drive a coding agent against a real codebase. Rules, skills, hooks. Three layers of paranoia built into the system instead of relying on any one person's vigilance on a random Friday. That post was about the merge gate: what stops garbage from landing on `main`.
 
 Part of that merge gate is worth calling out on its own: a second pass on the same PR, same harness, different system prompt, catches things the first pass missed. You don't need a different vendor or a different model for that to work, just a fresh set of eyes that didn't write the code. [I wrote more about why that works here.](https://www.mattstratton.com/newsletter/was-it-the-model-or-just-a-fresh-pass-uncommitted/)
 
@@ -95,4 +95,4 @@ Take that human out of the loop, or just make them faster and more numerous by h
 
 The agent didn't create this problem. It just removed the friction that used to hide it.
 
-*Same as last time: if you want the receipts on how the merge-side guardrails work, [that's here](https://dev.to/mattstratton/how-my-coworker-who-didnt-know-cd-shipped-to-production-3j6j). This one's the other half.*
+*Same as last time: if you want the receipts on how the merge-side guardrails work, [that's here](/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production/). This one's the other half.*

--- a/src/content/writing/finance-101-budgets-pls-and-the-language-of-money.md
+++ b/src/content/writing/finance-101-budgets-pls-and-the-language-of-money.md
@@ -10,7 +10,7 @@ heroImage: /writing/finance-101-budgets-pls-and-the-language-of-money/qg4giv7gqc
 
 ![](/writing/finance-101-budgets-pls-and-the-language-of-money/qg4giv7gqcufvzmejpgr.png)
 
-*This is Part 4 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
+*This is Part 4 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/).*
 
 Time for everyone's favorite topic: money. Specifically, how companies think about money, track money, and make decisions about money.
 
@@ -230,6 +230,6 @@ Look, finance isn't the hippest part of business literacy. But it might be the m
 *Questions about budgets? Confused about the difference between CapEx and OpEx? Want to share your budget horror stories? Comments are open.*
 
 ---
-**Previously:** [Part 3: Marketing 101](https://dev.to/mattstratton/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81)
+**Previously:** [Part 3: Marketing 101](/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/)
 
-**Next up:** [Product 101](https://dev.to/mattstratton/product-101-your-secret-weapon-for-understanding-the-business-2m6j)
+**Next up:** [Product 101](/writing/product-101-your-secret-weapon-for-understanding-the-business/)

--- a/src/content/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production.md
+++ b/src/content/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production.md
@@ -50,7 +50,7 @@ The downside of teaching a designer to use the terminal is that she will want he
 
 Hold both of these facts in your brain at the same time: Tanya is asking me what `cd` does this morning. Tanya shipped a real feature to a real codebase last week.
 
-If you read [my last post on coding agents and internal tooling](https://dev.to/mattstratton/coding-agents-are-actually-good-at-this-one-thing-5dej), you know where I ended it. The caveat was that I was a solo contributor to a real codebase, and the first comment on the post called out exactly the right thing. *Who owns this when you leave?* That's a reasonable question. In March, my answer was "me, and that's a problem."
+If you read [my last post on coding agents and internal tooling](/writing/coding-agents-are-actually-good-at-this-one-thing/), you know where I ended it. The caveat was that I was a solo contributor to a real codebase, and the first comment on the post called out exactly the right thing. *Who owns this when you leave?* That's a reasonable question. In March, my answer was "me, and that's a problem."
 
 My answer in April is "...and also Tanya."
 

--- a/src/content/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means.md
+++ b/src/content/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means.md
@@ -10,7 +10,7 @@ heroImage: /writing/marketing-101-funnels-campaigns-and-what-marketing-actually-
 
 ![](/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/zyg785kv0b888acwdq7l.png)
 
-*This is Part 3 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
+*This is Part 3 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/).*
 
 Let's talk about the relationship between DevRel and marketing. And if you just shuddered uncontrollably, you're exactly who I'm writing this for.
 
@@ -207,7 +207,7 @@ Next up: Finance 101. Because understanding budgets, P&Ls, and why your CFO care
 *Got thoughts on the DevRel/marketing relationship? Think I'm totally wrong about something? Let's talk about it in the comments.*
 
 ---
-**Previously:** [Part 2: Sales 101](https://dev.to/mattstratton/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8)
+**Previously:** [Part 2: Sales 101](/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/)
 
 **Next up:** [Finance 101]( 
-https://dev.to/mattstratton/finance-101-budgets-pls-and-the-language-of-money-3dp9)
+/writing/finance-101-budgets-pls-and-the-language-of-money/)

--- a/src/content/writing/product-101-your-secret-weapon-for-understanding-the-business.md
+++ b/src/content/writing/product-101-your-secret-weapon-for-understanding-the-business.md
@@ -10,7 +10,7 @@ heroImage: /writing/product-101-your-secret-weapon-for-understanding-the-busines
 
 ![](/writing/product-101-your-secret-weapon-for-understanding-the-business/yul3alsercwqflrzkk8m.png)
 
-*This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
+*This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/).*
 
 We've covered sales, marketing, and finance. But there's one group we haven't talked about yet - and they might be your most valuable partnership in the entire company: **Product**.
 
@@ -300,6 +300,6 @@ Next up: we'll talk about Product-Led Growth and how it changes everything about
 *Questions about working with product? War stories about great (or terrible) product partnerships? Let's hear them in the comments!*
 
 ---
-**Previously:** [Part 4: Finance 101](https://dev.to/mattstratton/finance-101-budgets-pls-and-the-language-of-money-3dp9)
+**Previously:** [Part 4: Finance 101](/writing/finance-101-budgets-pls-and-the-language-of-money/)
 
-**Next up:** [Product-Led Growth](https://dev.to/mattstratton/product-led-growth-and-what-it-means-for-devrel-10mj)
+**Next up:** [Product-Led Growth](/writing/product-led-growth-and-what-it-means-for-devrel/)

--- a/src/content/writing/product-led-growth-and-what-it-means-for-devrel.md
+++ b/src/content/writing/product-led-growth-and-what-it-means-for-devrel.md
@@ -10,7 +10,7 @@ heroImage: /writing/product-led-growth-and-what-it-means-for-devrel/o6sijn10fab2
 
 ![](/writing/product-led-growth-and-what-it-means-for-devrel/o6sijn10fab2fuftqg2j.png)
 
-*This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
+*This is Part 5 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/).*
 
 We've covered sales, marketing, and finance - the three core business functions you need to understand. But there's one more concept that ties everything together, and it's especially critical if you work at a developer tools company or any company with a self-serve product: **Product-Led Growth** (PLG).
 
@@ -244,6 +244,6 @@ Next up, we're bringing it all together in the final post - how to actually use 
 *As always, comments are open below if you want to discuss, debate, or share your PLG experiences.*
 
 ---
-**Previously:** [Part 5: Product 101](https://dev.to/mattstratton/product-101-your-secret-weapon-for-understanding-the-business-2m6j9)
+**Previously:** [Part 5: Product 101](/writing/product-101-your-secret-weapon-for-understanding-the-business/)
 
-**Next up:** [Wrapping it all up](https://dev.to/mattstratton/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj)
+**Next up:** [Wrapping it all up](/writing/putting-it-all-together-speaking-business-as-a-devrel-professional/)

--- a/src/content/writing/putting-it-all-together-speaking-business-as-a-devrel-professional.md
+++ b/src/content/writing/putting-it-all-together-speaking-business-as-a-devrel-professional.md
@@ -10,7 +10,7 @@ heroImage: /writing/putting-it-all-together-speaking-business-as-a-devrel-profes
 
 ![](/writing/putting-it-all-together-speaking-business-as-a-devrel-professional/4f21cxu3z6d0ypgju4pa.png)
 
-*This is Part 7 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
+*This is Part 7 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/).*
 
 We've covered a lot of ground in this series. Sales pipelines and forecast accuracy. Marketing funnels and MQLs. P&Ls and CapEx vs OpEx. Product-Led Growth and how it changes the game for developer tools companies. If your brain feels a little full right now, that's normal. This is a lot of new vocabulary and new ways of thinking.
 

--- a/src/content/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in.md
+++ b/src/content/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in.md
@@ -10,7 +10,7 @@ heroImage: /writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/z
 
 ![](/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/zjpxkzku5xlxg42qlq49.png)
 
-*This is Part 2 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1).*
+*This is Part 2 of my 7-part series on business literacy for DevRel. [Start with Part 1 if you missed it](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/).*
 
 Let's talk about sales folks. And I need you to stick with me here, because I know what you're thinking.
 
@@ -167,6 +167,6 @@ Next up, we're tackling marketing. Because if you thought sales was misunderstoo
 *Questions? Confused about pipeline? Want to argue with me about whether DevRel should ever talk to sales? Drop a comment!*
 
 ---
-**Previously:** [Part 1: Why Business Literacy Matters](https://dev.to/mattstratton/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step-30p1)
+**Previously:** [Part 1: Why Business Literacy Matters](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/)
 
-**Next up:** [Marketing 101](https://dev.to/mattstratton/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81)
+**Next up:** [Marketing 101](/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/)

--- a/src/content/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step.md
+++ b/src/content/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step.md
@@ -23,12 +23,12 @@ But here's some tough love for you, from me: if you can't translate that work in
 > This is Part 1 of a 6-part series on business literacy for DevRel:
 > 
 > 1. **Why Business Literacy Matters** (you are here)
-> 2. [Sales 101](https://dev.to/mattstratton/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8)
-> 3. [Marketing 101](https://dev.to/mattstratton/marketing-101-funnels-campaigns-and-what-marketing-actually-means-4j81)
-> 4. [Finance 101](https://dev.to/mattstratton/finance-101-budgets-pls-and-the-language-of-money-3dp9)
-> 5. [Product-Led Growth](https://dev.to/mattstratton/product-led-growth-and-what-it-means-for-devrel-10mj)
-> 6. [Product 101](https://dev.to/mattstratton/product-101-your-secret-weapon-for-understanding-the-business-2m6j)
-> 7. [Putting It All Together](https://dev.to/mattstratton/putting-it-all-together-speaking-business-as-a-devrel-professional-2kfj)
+> 2. [Sales 101](/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/)
+> 3. [Marketing 101](/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/)
+> 4. [Finance 101](/writing/finance-101-budgets-pls-and-the-language-of-money/)
+> 5. [Product-Led Growth](/writing/product-led-growth-and-what-it-means-for-devrel/)
+> 6. [Product 101](/writing/product-101-your-secret-weapon-for-understanding-the-business/)
+> 7. [Putting It All Together](/writing/putting-it-all-together-speaking-business-as-a-devrel-professional/)
 
 ## The Uncomfortable Truth About DevRel Right Now
 
@@ -132,4 +132,4 @@ Have you struggled to communicate DevRel value to non-technical stakeholders? Wh
 
 ---
 
-**Next in this series:** [Sales 101](https://dev.to/mattstratton/sales-101-what-your-sales-team-does-and-how-devrel-fits-in-29d8)
+**Next in this series:** [Sales 101](/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/)

--- a/src/content/writing/zshrc-tour.md
+++ b/src/content/writing/zshrc-tour.md
@@ -92,7 +92,7 @@ Type `issue 412` and it spins up Claude Code in plan mode, in its own worktree n
 
 ## atuin and starship deserve more than a name-drop
 
-I mentioned in [My Brewfile](https://dev.to/mattstratton/my-brewfile-1pob) that I install both of these, but I glossed over why, so let's fix that.
+I mentioned in [My Brewfile](/writing/my-brewfile-1pob/) that I install both of these, but I glossed over why, so let's fix that.
 
 ```bash
 eval "$(atuin init zsh)"


### PR DESCRIPTION
## Summary
Scanned all 17 crossposted \`src/content/writing/\` entries (not just the DevRel series — per request, checked everything) for links pointing at other dev.to posts, and rewrote each one whose target has also been crossposted to a relative \`/writing/<slug>/\` link.

- **27 links across 10 files** rewritten, covering the full 7-part DevRel series' cross-references ("Start with Part 1", "Next in this series"), \`decouple-release-from-deploy\` → \`how-my-coworker-who-didnt-know-cd-shipped-to-production\`, and \`zshrc-tour\` → \`my-brewfile\`.
- **Left untouched**: the link from \`how-my-coworker...\` to \`shifting-left-securely-with-inspec\`, since that post hasn't been crossposted.
- **Bonus fix**: \`product-led-growth-and-what-it-means-for-devrel\` had a pre-existing typo in its link to Product 101 (extra trailing \`9\` on the slug — already dead on dev.to) — corrected to point at the real crossposted URL.

Caught and fixed a real bug in my own first pass before committing: naive substring replacement without longest-match-first ordering left a dangling \`9\` after the typo'd link's replacement (since the correct slug is a literal prefix of the typo'd one). Reverted and redid the whole batch with slugs sorted longest-first, confirmed via a follow-up scan that no prefix collisions remain anywhere in the set.

## Test plan
- [x] \`npm test\` — 62/62 pass
- [x] \`npm run build\` succeeds
- [x] Re-scanned all 17 files post-rewrite — zero remaining links to crossposted posts, confirmed the untouched external link and the typo fix are both correct
- [x] Spot-checked 4 rewritten link targets locally — all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)