### PR TITLE
Fix three small housekeeping issues (#59, #55, #47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ A design-system unification (the warm-paper CSS tokens are currently hand-copied
 
 **Claude Code skills note**: `mattstratton-speaking/.claude/skills/` (`add-talk`, `resync-talk-memory`, `transcript-cleanup`) are committed and are discovered correctly from a Claude Code session at this repo's root — confirmed working post-merge, no `cd` workaround needed.
 
+**CLAUDE.md discovery**: this repo's root `CLAUDE.md` always loads for a Claude Code session started here; the nested `mattstratton-speaking/CLAUDE.md` and `mattstratton-dev-to/CLAUDE.md` are picked up automatically based on which subdirectory's files are being read or edited — no manual `cd` or extra config needed. Keeping three separate files is intentional, not an oversight: each subproject is a genuinely distinct, self-contained codebase (different stack details, URL rules, content models), so consolidating them into one file would just bloat it with irrelevant detail for whichever subproject a session isn't touching.
+
 **GitHub Actions gotcha**: workflow files are ONLY discovered by GitHub at the true repo root's `.github/workflows/` — never in a subdirectory. `mattstratton-dev-to`'s workflows live at the root `.github/workflows/devto-import.yml` and `devto-publish.yml` (not nested under `mattstratton-dev-to/`), each scoped back to that subdirectory via `working-directory`/`files`/`paths` settings inside the workflow. If a future merged subproject brings its own `.github/workflows/`, they need the same treatment — move to root, rename to avoid collisions, keep the path scoping.
 
 ## Commands

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.mattstratton.com/sitemap-index.xml

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,6 +72,11 @@
     --tw-prose-quotes: var(--color-ink);
     --tw-prose-code: var(--color-accent);
   }
+
+  .prose code::before,
+  .prose code::after {
+    content: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Suppress `@tailwindcss/typography`'s default `code::before`/`code::after` backtick decoration so inline code on `/writing/` (and legacy `/posts/`) pages stops showing literal backticks
- Clarify in root `CLAUDE.md` how CLAUDE.md discovery works across the monorepo's three subprojects, confirming the current per-directory setup is intentional (no consolidation needed)
- Add `public/robots.txt` to mattstratton.com pointing at its sitemap, matching what speaking.mattstratton.com already has

Closes #59
Closes #55
Closes #47

## Test plan
- [x] `npm run build` succeeds and generates `dist/robots.txt` with correct content
- [x] Verified in browser (preview server) that inline code (e.g. `` `main` ``) renders without surrounding backticks on a writing post, while fenced code blocks are unaffected
- [x] Confirmed no conflicting/duplicated guidance exists across the three CLAUDE.md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)