### PR TITLE
Add committed Claude Code config: push guardrail, /pr and /verify-ui skills

### DIFF
--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — blocks direct `git push` to master/main so
+# changes always go through a branch + PR. See .claude/skills/pr/SKILL.md.
+set -euo pipefail
+
+input="$(cat)"
+command="$(echo "$input" | jq -r '.tool_input.command // empty')"
+
+[[ -z "$command" ]] && exit 0
+[[ "$command" != *"git push"* ]] && exit 0
+
+target_branch=""
+if [[ "$command" =~ push[[:space:]]+[^[:space:]]+[[:space:]]+([^[:space:]:]+) ]]; then
+  target_branch="${BASH_REMATCH[1]}"
+fi
+
+if [[ -z "$target_branch" ]]; then
+  target_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+fi
+
+if [[ "$target_branch" == "master" || "$target_branch" == "main" ]]; then
+  echo "Blocked: direct 'git push' to '$target_branch' is not allowed. Create a branch and use the /pr skill to open a pull request instead." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "enabledPlugins": ["superpowers@claude-plugins-official"],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-push-to-main.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: pr
+description: Build, test, review, and ship the current changes as a pull request. Use when the user says "/pr", "open a PR", "ship this", or asks to push their work up for review.
+---
+
+# pr
+
+Take the working tree's changes from "done" to "open PR," scoped for a solo-maintained
+repo (no draft-PR pause, no parallel security/a11y review bots — just enough
+automation to catch mistakes before they ship).
+
+## Steps
+
+1. **Check the branch.** If currently on `master` or `main`, create a new branch
+   first (name it for the change, e.g. `fix/nav-overflow`). Direct pushes to
+   `master`/`main` are hard-blocked by `.claude/hooks/block-push-to-main.sh`, so
+   this step isn't optional.
+2. **Build and test.** Run `npm run build` and `npm test` from the repo root (or
+   from the relevant subproject — `mattstratton-speaking/` and
+   `mattstratton-dev-to/` each have their own `package.json` and must be run from
+   inside that directory). Stop and fix before continuing if either fails.
+3. **Review the diff.** Run the `code-review` skill against the changes. Apply
+   fixes for anything it flags as a real issue; use judgement on stylistic
+   nitpicks.
+4. **Commit.** Follow this repo's normal commit conventions (see the root
+   `CLAUDE.md` — specific files staged, not `git add -A`; message ends with the
+   `Co-Authored-By` trailer). Never commit files that look like they might hold
+   secrets (`.env`, credentials) without double-checking their contents first.
+5. **Push and open the PR.** Push the branch, then `gh pr create` with a concise
+   title and a body summarizing the change and how it was verified. Open it
+   **ready for review**, not draft — there's no second reviewer waiting on draft
+   status here.
+
+## When to skip this skill
+
+For a trivial one-line fix the user explicitly wants pushed directly, just ask
+whether they want the full flow or a quick manual commit — don't force the
+branch+PR ceremony on something that doesn't need it.

--- a/.claude/skills/verify-ui/SKILL.md
+++ b/.claude/skills/verify-ui/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: verify-ui
+description: Visually verify a UI change by capturing it in light mode, dark mode, and a mobile viewport using Chrome automation. Use when the user says "/verify-ui", "check the UI", "verify this looks right", or after making changes to layouts, components, or styling that should be visually confirmed before shipping.
+---
+
+# verify-ui
+
+Formalizes the manual light/dark/mobile check that `mattstratton-speaking/CLAUDE.md`
+already calls for after UI changes. Run this standalone, on demand — it is not
+wired into `/pr`.
+
+## Steps
+
+1. **Start the dev server** for whichever subproject changed (`npm run dev` from
+   the repo root, `mattstratton-speaking/`, etc.) if it isn't already running.
+2. **Load the deferred Chrome tools** in one `ToolSearch` call:
+   `select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__tabs_create_mcp`.
+3. **Identify the page(s) to check** — the route(s) touched by the diff, or ask
+   the user if it's not obvious from the changed files.
+4. **Capture each page in three states**, saving screenshots to disk (not just
+   describing them):
+   - Light mode, desktop viewport.
+   - Dark mode, desktop viewport (toggle via the site's theme control, or
+     `prefers-color-scheme` emulation if the site has no manual toggle).
+   - Mobile viewport (narrow width, e.g. ~375px), default color scheme.
+5. **Check for the known failure modes** this codebase cares about: broken tap
+   targets or overflow at narrow widths, missing focus outlines, body text below
+   WCAG AA contrast, and any element that doesn't degrade gracefully when an
+   asset (image, video, slide) is absent.
+6. **Report findings** — call out anything that looks broken with the specific
+   screenshot as evidence, rather than a general "looks fine."
+
+## Notes
+
+- Avoid triggering JS `alert`/`confirm`/`prompt` dialogs during capture — they
+  block the extension. If a control might trigger one, skip clicking it and note
+  why.
+- If Chrome tool calls fail repeatedly or a page won't load, stop and report
+  what was attempted rather than retrying in a loop.


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` (committed) requiring the `superpowers` plugin, matching what `mattstratton-speaking/CLAUDE.md` already assumes.
- Adds `.claude/hooks/block-push-to-main.sh`, a `PreToolUse`/`Bash` hook that hard-blocks direct `git push` to `master`/`main`, forcing a branch + PR flow.
- Adds `.claude/skills/pr/SKILL.md` — a scaled-down build → test → code-review → commit → push → `gh pr create` (ready-for-review) flow.
- Adds `.claude/skills/verify-ui/SKILL.md` — formalizes the manual light/dark/mobile visual check already called for in `mattstratton-speaking/CLAUDE.md`, using Chrome automation.

These patterns were adapted from `timescale/tiger-den`'s Claude Code configuration and scoped down for a solo-maintained repo (no draft-PR pause, no parallel security/a11y review bots, no Linear/DB-refresh/third-party-skill-vendoring machinery).

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — all 62 tests pass
- [x] `code-review` skill run against the diff — no findings
- [x] Manually verified `block-push-to-main.sh`: blocks `git push` and `git push origin master` while on `master`, allows pushing a feature branch, ignores non-push commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)