### PR TITLE
fix: correct enabledPlugins shape in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,7 @@
 {
-  "enabledPlugins": ["superpowers@claude-plugins-official"],
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary
- `/doctor` flagged `.claude/settings.json`'s `enabledPlugins` as an array when the schema expects a record (plugin name → boolean).
- Converted `["superpowers@claude-plugins-official"]` to `{ "superpowers@claude-plugins-official": true }`.

## Test plan
- [x] Ran `/doctor` locally and confirmed the schema error is resolved.