### PR TITLE
Auto-crosspost eligible dev.to posts via GitHub Action

### DIFF
--- a/.github/workflows/devto-crosspost.yml
+++ b/.github/workflows/devto-crosspost.yml
@@ -1,0 +1,79 @@
+name: Crosspost eligible dev.to posts to writing collection
+
+on:
+  pull_request:
+    paths:
+      - "mattstratton-dev-to/posts/**/*.md"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: devto-crosspost-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  crosspost:
+    runs-on: ubuntu-latest
+    # Same-repo PRs only: GITHUB_TOKEN is force-read-only for fork PRs on
+    # `pull_request`, so a push there would fail anyway.
+    # Loop guard: don't re-run on this job's own write-back commit.
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: List dev.to post files changed in this PR
+        id: changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename' \
+            | grep -E '^mattstratton-dev-to/posts/[A-Za-z0-9._-]+\.md$' || true)
+          {
+            echo "files<<EOF"
+            echo "$files"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Crosspost eligible + changed posts
+        if: steps.changed.outputs.files != ''
+        env:
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+          eligible=$(npm run --silent crosspost | sed -n 's/^  - //p' || true)
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            base=$(basename "$f")
+            if printf '%s\n' "$eligible" | grep -qx "$base"; then
+              echo "Crossposting $base"
+              npm run --silent crosspost -- "$base" --skip-if-exists
+            fi
+          done <<< "$FILES"
+
+      - name: Commit and push generated writing entries onto this PR
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add mattstratton-dev-to/posts src/content/writing public/writing
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore: crosspost eligible dev.to post(s) to writing collection"
+          git push origin "HEAD:refs/heads/$HEAD_REF"

--- a/scripts/crosspost-devto.ts
+++ b/scripts/crosspost-devto.ts
@@ -9,7 +9,7 @@
  * git-owned (have an `id`). Create-only: refuses to touch a writing entry that
  * already exists, so a later run can never clobber manual edits.
  *
- * Run: npm run crosspost -- <devto-filename> [--slug x] [--pub-date x] [--override-canonical]
+ * Run: npm run crosspost -- <devto-filename> [--slug x] [--pub-date x] [--override-canonical] [--skip-if-exists]
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
@@ -184,12 +184,16 @@ export function buildWritingFrontmatter(input: WritingFrontmatterInput): Record<
 
 function parseArgs(argv: string[]) {
   const positional: string[] = [];
-  const opts: { slug?: string; pubDate?: string; overrideCanonical: boolean } = { overrideCanonical: false };
+  const opts: { slug?: string; pubDate?: string; overrideCanonical: boolean; skipIfExists: boolean } = {
+    overrideCanonical: false,
+    skipIfExists: false,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--slug') opts.slug = argv[++i];
     else if (a === '--pub-date') opts.pubDate = argv[++i];
     else if (a === '--override-canonical') opts.overrideCanonical = true;
+    else if (a === '--skip-if-exists') opts.skipIfExists = true;
     else positional.push(a);
   }
   return { file: positional[0], ...opts };
@@ -225,11 +229,11 @@ function gitFirstCommitDate(absPath: string): string | undefined {
 }
 
 async function main() {
-  const { file, slug: slugOverride, pubDate: pubDateOverride, overrideCanonical } = parseArgs(process.argv.slice(2));
+  const { file, slug: slugOverride, pubDate: pubDateOverride, overrideCanonical, skipIfExists } = parseArgs(process.argv.slice(2));
 
   if (!file) {
     const eligible = listEligiblePosts();
-    console.log('Usage: npm run crosspost -- <devto-filename> [--slug x] [--pub-date x] [--override-canonical]\n');
+    console.log('Usage: npm run crosspost -- <devto-filename> [--slug x] [--pub-date x] [--override-canonical] [--skip-if-exists]\n');
     console.log(eligible.length ? 'Eligible posts (crosspost: true, has id):' : 'No eligible posts found (need crosspost: true and an existing id).');
     for (const f of eligible) console.log(`  - ${f}`);
     process.exitCode = eligible.length ? 0 : 1;
@@ -246,13 +250,17 @@ async function main() {
 
   if (!fm.id) throw new Error(`${filename} has no id — not git-owned yet, cannot crosspost.`);
   if (fm.crosspost !== true) throw new Error(`${filename} is not flagged for crosspost — add \`crosspost: true\` to its frontmatter first.`);
-  checkCanonicalHost(typeof fm.canonical_url === 'string' ? fm.canonical_url : undefined, overrideCanonical);
 
   const slug = slugOverride || deriveSlug(filename);
   const targetPath = join(WRITING_DIR, `${slug}.md`);
   if (existsSync(targetPath)) {
+    if (skipIfExists) {
+      console.log(`${targetPath} already exists — skipping (--skip-if-exists).`);
+      return;
+    }
     throw new Error(`${targetPath} already exists — already crossposted, or a slug collision. Use --slug to disambiguate.`);
   }
+  checkCanonicalHost(typeof fm.canonical_url === 'string' ? fm.canonical_url : undefined, overrideCanonical);
   console.log(`Derived slug: ${slug} (from ${filename}) — confirm this reads well as a URL before committing.`);
 
   const { date: pubDate, source } = resolvePubDate(fm.date, pubDateOverride, gitFirstCommitDate(sourcePath));


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/devto-crosspost.yml`: a `pull_request`-triggered Action that detects a touched `mattstratton-dev-to/posts/*.md` file flagged `crosspost: true` with a valid `id`, runs the existing `npm run crosspost` script, and pushes the generated `src/content/writing/<slug>.md` entry as an additional commit onto the same PR — following the existing PR-centric import/publish pattern instead of a manual CLI step or a redundant second PR.
- Adds a `--skip-if-exists` flag to `scripts/crosspost-devto.ts` so repeat `pull_request: synchronize` events on an already-crossposted PR are a clean no-op instead of a failing check.
- Guards against fork PRs (GITHUB_TOKEN is force-read-only there) and against re-triggering on its own write-back commit, matching the loop guard already used in `devto-publish.yml`.

Closes #53.

## Test plan
- [x] `npm test` passes (62/62)
- [x] Manually verified `--skip-if-exists` no-ops on an already-crossposted post, and the flag-less path still throws as before
- [ ] Open a real test PR flipping `crosspost: true` on an eligible post and confirm the Action pushes the generated writing entry onto the same PR, and a follow-up empty push to the PR is a clean no-op