### PR TITLE
Add cover images and topic tags to external field-guide entries

### DIFF
--- a/src/data/field-guide.ts
+++ b/src/data/field-guide.ts
@@ -13,6 +13,8 @@ export interface FieldGuideLink {
   description: string;
   part: PartKey;
   url: string;
+  image?: string;
+  topics?: string[];
 }
 
 export const externalFieldGuide: FieldGuideLink[] = [
@@ -23,6 +25,8 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'MVCC is great for concurrent workloads. For append-only data, it’s 23 bytes of overhead per row that never gets used. Here’s what that actually costs.',
     part: 'mechanics',
     url: 'https://www.tigerdata.com/blog/mvcc-feature-youre-paying-for-but-not-using',
+    image: 'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/03/V1.png',
+    topics: ['MVCC', 'Postgres'],
   },
   {
     title: 'Write Amplification in Postgres: The 3-4x Tax on Every Insert',
@@ -30,6 +34,8 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Every 1 KB insert in Postgres becomes ~2.5 KB of committed I/O before it’s done. Here’s where the multiplier comes from, and where the tuning knobs run out.',
     part: 'mechanics',
     url: 'https://www.tigerdata.com/blog/write-amplification-in-postgres-the-3-4x-tax-on-every-insert',
+    image: 'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/04/thumbnail--1-.png',
+    topics: ['write-amplification', 'Postgres'],
   },
   {
     title: 'When Continuous Ingestion Breaks Traditional Postgres',
@@ -37,6 +43,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Postgres maintenance depends on quiet periods your continuous workload eliminated. Here’s what happens inside the database when the gaps disappear.',
     part: 'mechanics',
     url: 'https://www.tigerdata.com/blog/when-continuous-ingestion-breaks-traditional-postgres',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/03/When-Continuous-Ingestion-Breaks-Traditional-Postgres-1280x720.png',
+    topics: ['ingestion', 'Postgres'],
   },
 
   // Part 2 — Why you're hitting the wall
@@ -46,6 +55,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'PostgreSQL hits hard limits under analytics workloads. Here’s why MVCC, WAL, and row storage compound, and what to do instead.',
     part: 'limits',
     url: 'https://www.tigerdata.com/blog/postgres-optimization-treadmill',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/02/advocacy-essay-thumbnail-with-elephant.png',
+    topics: ['performance', 'Postgres'],
   },
   {
     title: 'Six Signs That Postgres Tuning Won’t Fix Your Performance Problems',
@@ -53,6 +65,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'When Postgres tuning won’t fix performance: recognize the six characteristics of time-series workloads that need a purpose-built architecture.',
     part: 'limits',
     url: 'https://www.tigerdata.com/blog/six-signs-postgres-tuning-wont-fix-performance-problems',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/02/Postgres-Tuning-Performance-compressed.png',
+    topics: ['tuning', 'Postgres'],
   },
   {
     title: 'Postgres Performance: Why Peak Throughput Benchmarks Miss the Real Problem',
@@ -60,6 +75,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Peak throughput tells you what Postgres can do in a sprint. Production asks what it can do forever. Those are different questions.',
     part: 'limits',
     url: 'https://www.tigerdata.com/blog/postgres-performance-why-peak-throughput-benchmarks-miss-real-problem',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/03/The-Database-Question-Nobody-Asks.png',
+    topics: ['benchmarking', 'Postgres'],
   },
   {
     title: 'Vertical Scaling: Buying Time You Can’t Afford',
@@ -67,6 +85,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Postgres vertical scaling works, until it doesn’t. Why high-frequency ingestion workloads hit an architectural wall, and what to do about it.',
     part: 'limits',
     url: 'https://www.tigerdata.com/blog/vertical-scaling-buying-time-you-cant-afford',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/02/Blog-Thumbnail-1280x720.png',
+    topics: ['vertical-scaling', 'Postgres'],
   },
 
   // Part 3 — The traps
@@ -76,6 +97,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Every Postgres index is a flat tax on every insert. At high ingestion rates, that tax is the whole problem.',
     part: 'traps',
     url: 'https://www.tigerdata.com/blog/why-adding-more-indexes-eventually-makes-things-worse',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/03/Option-1-1200X627.png',
+    topics: ['indexing', 'Postgres'],
   },
   {
     title: 'The Hidden Costs of Table Partitioning at Scale',
@@ -83,6 +107,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Table partitioning fixes retention and pruning, but adds hidden costs in planning time, schema migrations, and ops overhead. Know the tradeoffs before you commit.',
     part: 'traps',
     url: 'https://www.tigerdata.com/blog/hidden-costs-table-partitioning-scale',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/03/Blog-Thumbnail-1280x720.png',
+    topics: ['partitioning', 'Postgres'],
   },
   {
     title: 'Read Replicas Don’t Solve Write Bottlenecks',
@@ -90,6 +117,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Read replicas fix read contention. They don’t fix write throughput. Here’s the mechanical reason why, and what actually changes the trajectory.',
     part: 'traps',
     url: 'https://www.tigerdata.com/blog/read-replicas-dont-solve-write-bottlenecks',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/04/Read-Replicas-Don-t-Solve-Write-Bottlenecks-V2.png',
+    topics: ['read-replicas', 'Postgres'],
   },
 
   // Part 4 — The decision
@@ -99,6 +129,8 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Optimization problems stay fixed. Architectural ones come back. A framework for knowing which you’re dealing with before you’ve spent months on the wrong fix.',
     part: 'decision',
     url: 'https://www.tigerdata.com/blog/optimization-vs-architecture-knowing-the-difference',
+    image: 'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/04/thumbnail-blog.png',
+    topics: ['architecture', 'Postgres'],
   },
   {
     title: 'The Best Time to Migrate Was at 10M Rows. The Second Best Time Is Now.',
@@ -106,6 +138,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Migration cost scales with data volume. The optimization tax you pay while waiting scales faster.',
     part: 'decision',
     url: 'https://www.tigerdata.com/blog/when-to-migrate-postgres-to-timescaledb',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/04/Best-time-to-migrate-Blog.png',
+    topics: ['migration', 'Postgres'],
   },
   {
     title: 'Document Databases: Be Honest',
@@ -113,6 +148,9 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'Most MongoDB pain isn’t a MongoDB problem. It’s a workload shape problem that would follow you to Postgres.',
     part: 'decision',
     url: 'https://www.tigerdata.com/blog/document-databases-be-honest',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/04/Document-Databases_-Be-Honest-V2.png',
+    topics: ['mongodb', 'document-databases'],
   },
   {
     title: 'ClickHouse Is Fast. Your Pipeline Isn’t.',
@@ -120,5 +158,8 @@ export const externalFieldGuide: FieldGuideLink[] = [
       'ClickHouse is fast. But the pipeline tax, ACID trade-offs, and two-system overhead are part of the decision too. Here’s the full picture.',
     part: 'decision',
     url: 'https://www.tigerdata.com/blog/clickhouse-is-fast-your-pipeline-isnt',
+    image:
+      'https://storage.ghost.io/c/6b/cb/6bcb39cf-9421-4bd1-9c9d-fa7b6755ba0e/content/images/2026/04/thumbnail-blog-thumbnail-1280x720--1-.png',
+    topics: ['clickhouse'],
   },
 ];

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -30,14 +30,41 @@ export function groupByPart(entries: CollectionEntry<'writing'>[]) {
   return { groups, ungrouped };
 }
 
-/** All distinct topics across published writing, alphabetical, with counts. */
-export function collectTopics(entries: CollectionEntry<'writing'>[]) {
-  return collectTaxonomy(publishedWriting(entries), (e) => e.data.topics);
+/** A topic-taggable item, whether a native post (on-site) or an external tigerdata.com link. */
+export interface TopicItem {
+  title: string;
+  href: string;
+  pubDate?: Date;
+  external: boolean;
+  topics: string[];
 }
 
-/** Published writing entries tagged with the given topic slug, newest first (already sorted by publishedWriting). */
+/** Native + external entries merged into one topic-taggable shape, for taxonomy purposes. */
+function allTopicItems(entries: CollectionEntry<'writing'>[]): TopicItem[] {
+  const nativeItems: TopicItem[] = publishedWriting(entries).map((e) => ({
+    title: e.data.title,
+    href: `/writing/${e.id}/`,
+    pubDate: e.data.pubDate,
+    external: false,
+    topics: e.data.topics,
+  }));
+  const externalItems: TopicItem[] = externalFieldGuide.map((l) => ({
+    title: l.title,
+    href: l.url,
+    external: true,
+    topics: l.topics ?? [],
+  }));
+  return [...nativeItems, ...externalItems];
+}
+
+/** All distinct topics across published writing + external field-guide links, alphabetical, with counts. */
+export function collectTopics(entries: CollectionEntry<'writing'>[]) {
+  return collectTaxonomy(allTopicItems(entries), (i) => i.topics);
+}
+
+/** Writing/field-guide items (native or external) tagged with the given topic slug, newest first. */
 export function writingForTopic(entries: CollectionEntry<'writing'>[], slug: string) {
-  return entriesForTerm(publishedWriting(entries), (e) => e.data.topics, slug);
+  return entriesForTerm(allTopicItems(entries), (i) => i.topics, slug);
 }
 
 /** A field-guide entry, whether a native post (on-site) or an external link. */
@@ -46,6 +73,7 @@ export interface GuideItem {
   description: string;
   href: string;
   external: boolean;
+  image?: string;
 }
 
 /**
@@ -58,16 +86,16 @@ export function buildFieldGuide(native: CollectionEntry<'writing'>[]) {
   const groups = PARTS.map((p) => {
     const nat: GuideItem[] = pub
       .filter((e) => e.data.part === p.key)
-      .map((e) => ({ title: e.data.title, description: e.data.description, href: `/writing/${e.id}/`, external: false }));
+      .map((e) => ({ title: e.data.title, description: e.data.description, href: `/writing/${e.id}/`, external: false, image: e.data.heroImage }));
     const ext: GuideItem[] = externalFieldGuide
       .filter((l) => l.part === p.key)
-      .map((l) => ({ title: l.title, description: l.description, href: l.url, external: true }));
+      .map((l) => ({ title: l.title, description: l.description, href: l.url, external: true, image: l.image }));
     return { key: p.key, label: p.label, blurb: p.blurb, items: [...nat, ...ext] };
   }).filter((g) => g.items.length > 0);
 
   const ungrouped: GuideItem[] = pub
     .filter((e) => !e.data.part)
-    .map((e) => ({ title: e.data.title, description: e.data.description, href: `/writing/${e.id}/`, external: false }));
+    .map((e) => ({ title: e.data.title, description: e.data.description, href: `/writing/${e.id}/`, external: false, image: e.data.heroImage }));
 
   return { groups, ungrouped };
 }

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -36,12 +36,19 @@ const topics = collectTopics(writingEntries);
             <a
               href={item.href}
               rel={item.external ? 'noopener' : undefined}
-              class="group block border-b border-rule py-4 transition-colors hover:bg-panel"
+              class="group flex items-start gap-4 border-b border-rule py-4 transition-colors hover:bg-panel"
             >
-              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">
-                {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
-              </h3>
-              <p class="mt-1 text-ink-soft">{item.description}</p>
+              {item.image ? (
+                <img src={item.image} alt="" loading="lazy" decoding="async" class="h-10 w-10 shrink-0 rounded-sm object-cover ring-1 ring-rule" />
+              ) : (
+                <span class="hidden h-10 w-10 shrink-0 sm:block" aria-hidden="true"></span>
+              )}
+              <div class="min-w-0">
+                <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">
+                  {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
+                </h3>
+                <p class="mt-1 text-ink-soft">{item.description}</p>
+              </div>
             </a>
           </li>
         ))}
@@ -55,9 +62,16 @@ const topics = collectTopics(writingEntries);
       <ul class="mt-4">
         {ungrouped.map((item: GuideItem) => (
           <li>
-            <a href={item.href} class="group block border-b border-rule py-4 transition-colors hover:bg-panel">
-              <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{item.title}</h3>
-              <p class="mt-1 text-ink-soft">{item.description}</p>
+            <a href={item.href} class="group flex items-start gap-4 border-b border-rule py-4 transition-colors hover:bg-panel">
+              {item.image ? (
+                <img src={item.image} alt="" loading="lazy" decoding="async" class="h-10 w-10 shrink-0 rounded-sm object-cover ring-1 ring-rule" />
+              ) : (
+                <span class="hidden h-10 w-10 shrink-0 sm:block" aria-hidden="true"></span>
+              )}
+              <div class="min-w-0">
+                <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{item.title}</h3>
+                <p class="mt-1 text-ink-soft">{item.description}</p>
+              </div>
             </a>
           </li>
         ))}

--- a/src/pages/writing/tags/[slug].astro
+++ b/src/pages/writing/tags/[slug].astro
@@ -22,10 +22,16 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
     <p class="label mt-3 normal-case tracking-normal">{items.length} posts</p>
   </section>
   <ul class="mt-6">
-    {items.map((e) => (
+    {items.map((item) => (
       <li class="flex gap-4 border-b border-rule py-2.5">
-        <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(e.data.pubDate)}</span>
-        <a href={`/writing/${e.id}/`} class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline">{e.data.title}</a>
+        <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{item.pubDate ? fmt(item.pubDate) : ''}</span>
+        <a
+          href={item.href}
+          rel={item.external ? 'noopener' : undefined}
+          class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline"
+        >
+          {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
+        </a>
       </li>
     ))}
   </ul>


### PR DESCRIPTION
## Summary
- Closes #43: added `image?: string` to `FieldGuideLink`, manually hardcoded each of the 14 external tigerdata.com posts' `og:image` URL (chosen over a build-time fetch loader to avoid a live network dependency on tigerdata.com during this site's builds), and wired minimal thumbnail rendering into `/writing/index.astro` — also threads through the previously-unused native `heroImage` field for consistency.
- Closes #42: added `topics?: string[]` to `FieldGuideLink`, hand-tagged all 14 entries, and unified native + external entries into one shape (`TopicItem`) so `collectTopics()`/`writingForTopic()` in `src/lib/writing.ts` fold both together — external posts now appear under `/writing/tags/` with an outbound link and "tigerdata.com ↗" badge.

## Test plan
- [x] `npm run build` — 3165 pages build cleanly, no errors
- [x] `npm test` — 62/62 pass
- [x] Verified via local dev server: `/writing/` shows thumbnails for both native and external entries; `/writing/tags/` lists new external-only topics (clickhouse, mvcc, indexing, etc.); `/writing/tags/clickhouse/` and `/writing/tags/mvcc/` correctly render the external entry with outbound link, `rel="noopener"`, badge, and no crash on missing pubDate

🤖 Generated with [Claude Code](https://claude.com/claude-code)