### PR TITLE
Add hero/thumbnail image treatment for /writing/ and the legacy archive

### DIFF
--- a/scripts/crosspost-devto.ts
+++ b/scripts/crosspost-devto.ts
@@ -290,9 +290,7 @@ async function main() {
 
   const { body: rewrittenBody, coverImage: rewrittenCover } = rewriteImageReferences(body, coverImageRaw, urlMap);
   const delinkedBody = delinkEmbeds(rewrittenBody);
-  // heroImage isn't rendered by WritingLayout.astro yet, so also embed the
-  // cover inline — that's the only path that actually displays today.
-  const finalBody = rewrittenCover ? `![](${rewrittenCover})\n\n${delinkedBody.trim()}` : delinkedBody.trim();
+  const finalBody = delinkedBody.trim();
 
   const newFm = buildWritingFrontmatter({
     title: String(fm.title ?? slug),

--- a/src/components/ThumbnailCard.astro
+++ b/src/components/ThumbnailCard.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  src?: string;
+  alt?: string;
+  class?: string;
+}
+const { src, alt = '', class: className = '' } = Astro.props;
+---
+
+<div class={`relative aspect-video w-28 shrink-0 overflow-hidden rounded-sm bg-ink/5 ring-1 ring-rule sm:w-36 ${className}`}>
+  {src ? (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      class="h-full w-full object-cover grayscale-[0.15] transition duration-300 group-hover:grayscale-0"
+    />
+  ) : (
+    <div class="flex h-full w-full items-center justify-center text-ink/20" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+        <rect x="3" y="5" width="18" height="14" rx="1.5" />
+        <circle cx="8.5" cy="10" r="1.5" />
+        <path d="M21 16.5l-5.5-5.5a1.5 1.5 0 0 0-2.1 0L4 20" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </div>
+  )}
+</div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,6 +25,9 @@ const writing = defineCollection({
     // Set when the canonical version lives elsewhere (e.g. a tigerdata.com cross-post).
     canonicalUrl: z.string().url().optional(),
     heroImage: z.string().optional(),
+    // True when heroImage also appears inline in the body (legacy crossposts that
+    // embedded the cover directly) — WritingLayout then skips the top hero.
+    heroInBody: z.boolean().default(false),
   }),
 });
 

--- a/src/content/writing/coding-agents-are-actually-good-at-this-one-thing.md
+++ b/src/content/writing/coding-agents-are-actually-good-at-this-one-thing.md
@@ -6,6 +6,7 @@ topics:
   - webdev
 draft: false
 heroImage: /writing/coding-agents-are-actually-good-at-this-one-thing/rxoya791llxf4y6v2c81.png
+heroInBody: true
 ---
 
 ![](/writing/coding-agents-are-actually-good-at-this-one-thing/rxoya791llxf4y6v2c81.png)

--- a/src/content/writing/decouple-release-from-deploy.md
+++ b/src/content/writing/decouple-release-from-deploy.md
@@ -9,6 +9,7 @@ topics:
   - cicd
 draft: false
 heroImage: /writing/decouple-release-from-deploy/decouple-release-from-deploy-cover.png
+heroInBody: true
 ---
 
 ![](/writing/decouple-release-from-deploy/decouple-release-from-deploy-cover.png)

--- a/src/content/writing/dont-fear-the-cfp.md
+++ b/src/content/writing/dont-fear-the-cfp.md
@@ -6,6 +6,7 @@ topics:
   - public-speaking
 draft: false
 heroImage: /writing/dont-fear-the-cfp/jf16mw214n6h8zpwnz12.png
+heroInBody: true
 ---
 
 ![](/writing/dont-fear-the-cfp/jf16mw214n6h8zpwnz12.png)

--- a/src/content/writing/finance-101-budgets-pls-and-the-language-of-money.md
+++ b/src/content/writing/finance-101-budgets-pls-and-the-language-of-money.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/finance-101-budgets-pls-and-the-language-of-money/qg4giv7gqcufvzmejpgr.png
+heroInBody: true
 ---
 
 ![](/writing/finance-101-budgets-pls-and-the-language-of-money/qg4giv7gqcufvzmejpgr.png)

--- a/src/content/writing/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it.md
+++ b/src/content/writing/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it.md
@@ -6,6 +6,7 @@ topics:
   - events
 draft: false
 heroImage: /writing/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it/fyljvgmlrvoeqhr5qyn8.png
+heroInBody: true
 ---
 
 ![](/writing/hosting-a-participant-first-conference-in-the-age-of-corona-how-to-do-it/fyljvgmlrvoeqhr5qyn8.png)

--- a/src/content/writing/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me.md
+++ b/src/content/writing/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me.md
@@ -6,6 +6,7 @@ topics:
   - devops
 draft: false
 heroImage: /writing/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me/38h2hq4ti2m5uc5k79z4.png
+heroInBody: true
 ---
 
 ![](/writing/hot-takes-myths-and-fake-news---why-everyone-is-wrong-about-devops-except-for-me/38h2hq4ti2m5uc5k79z4.png)

--- a/src/content/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production.md
+++ b/src/content/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production.md
@@ -6,6 +6,7 @@ topics:
   - webdev
 draft: false
 heroImage: /writing/how-my-coworker-who-didnt-know-cd-shipped-to-production/huq5hzde2dcbh58cle1i.png
+heroInBody: true
 ---
 
 ![](/writing/how-my-coworker-who-didnt-know-cd-shipped-to-production/huq5hzde2dcbh58cle1i.png)

--- a/src/content/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means.md
+++ b/src/content/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/zyg785kv0b888acwdq7l.png
+heroInBody: true
 ---
 
 ![](/writing/marketing-101-funnels-campaigns-and-what-marketing-actually-means/zyg785kv0b888acwdq7l.png)

--- a/src/content/writing/mattstratton-com-stack.md
+++ b/src/content/writing/mattstratton-com-stack.md
@@ -8,6 +8,7 @@ topics:
   - showdev
 draft: false
 heroImage: /writing/mattstratton-com-stack/mattstratton-com-stack-cover.png
+heroInBody: true
 ---
 
 ![](/writing/mattstratton-com-stack/mattstratton-com-stack-cover.png)

--- a/src/content/writing/my-brewfile-1pob.md
+++ b/src/content/writing/my-brewfile-1pob.md
@@ -6,6 +6,7 @@ topics:
   - homebrew
 draft: false
 heroImage: /writing/my-brewfile-1pob/e2bcvnrx9shjhpqfy8l5.png
+heroInBody: true
 ---
 
 ![](/writing/my-brewfile-1pob/e2bcvnrx9shjhpqfy8l5.png)

--- a/src/content/writing/product-101-your-secret-weapon-for-understanding-the-business.md
+++ b/src/content/writing/product-101-your-secret-weapon-for-understanding-the-business.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/product-101-your-secret-weapon-for-understanding-the-business/yul3alsercwqflrzkk8m.png
+heroInBody: true
 ---
 
 ![](/writing/product-101-your-secret-weapon-for-understanding-the-business/yul3alsercwqflrzkk8m.png)

--- a/src/content/writing/product-led-growth-and-what-it-means-for-devrel.md
+++ b/src/content/writing/product-led-growth-and-what-it-means-for-devrel.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/product-led-growth-and-what-it-means-for-devrel/o6sijn10fab2fuftqg2j.png
+heroInBody: true
 ---
 
 ![](/writing/product-led-growth-and-what-it-means-for-devrel/o6sijn10fab2fuftqg2j.png)

--- a/src/content/writing/putting-it-all-together-speaking-business-as-a-devrel-professional.md
+++ b/src/content/writing/putting-it-all-together-speaking-business-as-a-devrel-professional.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/putting-it-all-together-speaking-business-as-a-devrel-professional/4f21cxu3z6d0ypgju4pa.png
+heroInBody: true
 ---
 
 ![](/writing/putting-it-all-together-speaking-business-as-a-devrel-professional/4f21cxu3z6d0ypgju4pa.png)

--- a/src/content/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in.md
+++ b/src/content/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/zjpxkzku5xlxg42qlq49.png
+heroInBody: true
 ---
 
 ![](/writing/sales-101-what-your-sales-team-does-and-how-devrel-fits-in/zjpxkzku5xlxg42qlq49.png)

--- a/src/content/writing/the-monorepo-song.md
+++ b/src/content/writing/the-monorepo-song.md
@@ -6,6 +6,7 @@ topics:
   - humor
 draft: false
 heroImage: /writing/the-monorepo-song/1gwecfd4ed3nf07pjlee.jpg
+heroInBody: true
 ---
 
 ![](/writing/the-monorepo-song/1gwecfd4ed3nf07pjlee.jpg)

--- a/src/content/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step.md
+++ b/src/content/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step.md
@@ -6,6 +6,7 @@ topics:
   - devrel
 draft: false
 heroImage: /writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/558ps6yn849q6cvqoiyz.png
+heroInBody: true
 ---
 
 ![](/writing/why-business-literacy-matters-for-devrel-and-why-you-cant-skip-this-step/558ps6yn849q6cvqoiyz.png)

--- a/src/content/writing/zshrc-tour.md
+++ b/src/content/writing/zshrc-tour.md
@@ -9,6 +9,7 @@ topics:
   - productivity
 draft: false
 heroImage: /writing/zshrc-tour/zshrc-tour-cover.png
+heroInBody: true
 ---
 
 ![](/writing/zshrc-tour/zshrc-tour-cover.png)

--- a/src/layouts/WritingLayout.astro
+++ b/src/layouts/WritingLayout.astro
@@ -41,6 +41,16 @@ const updated = d.updatedDate?.toLocaleDateString('en-US', { year: 'numeric', mo
       )}
     </header>
 
+    {d.heroImage && !d.heroInBody && (
+      <img
+        src={d.heroImage}
+        alt={d.title}
+        loading="eager"
+        decoding="async"
+        class="mt-8 aspect-video w-full rounded-sm object-cover ring-1 ring-rule"
+      />
+    )}
+
     <div class="prose prose-lg mt-8 max-w-none">
       <slot />
     </div>

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -37,6 +37,7 @@ export interface TopicItem {
   pubDate?: Date;
   external: boolean;
   topics: string[];
+  image?: string;
 }
 
 /** Native + external entries merged into one topic-taggable shape, for taxonomy purposes. */
@@ -47,12 +48,14 @@ function allTopicItems(entries: CollectionEntry<'writing'>[]): TopicItem[] {
     pubDate: e.data.pubDate,
     external: false,
     topics: e.data.topics,
+    image: e.data.heroImage,
   }));
   const externalItems: TopicItem[] = externalFieldGuide.map((l) => ({
     title: l.title,
     href: l.url,
     external: true,
     topics: l.topics ?? [],
+    image: l.image,
   }));
   return [...nativeItems, ...externalItems];
 }

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
+import ThumbnailCard from '../../components/ThumbnailCard.astro';
 import { collectTaxonomy, postsForTerm } from '../../lib/posts';
 
 export async function getStaticPaths() {
@@ -23,9 +24,12 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
   </section>
   <ul class="mt-6">
     {posts.map((p) => (
-      <li class="flex gap-4 border-b border-rule py-2.5">
-        <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(p.data.date)}</span>
-        <a href={`/${p.data.permalink}/`} class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline">{p.data.title}</a>
+      <li class="border-b border-rule py-2.5">
+        <a href={`/${p.data.permalink}/`} class="group flex items-center gap-4">
+          <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(p.data.date)}</span>
+          <ThumbnailCard src={p.data.image} />
+          <span class="decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{p.data.title}</span>
+        </a>
       </li>
     ))}
   </ul>

--- a/src/pages/post/index.astro
+++ b/src/pages/post/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
+import ThumbnailCard from '../../components/ThumbnailCard.astro';
 import { groupByYear } from '../../lib/posts';
 
 const posts = await getCollection('posts');
@@ -35,14 +36,12 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'n
       <h2 class="font-display text-3xl font-semibold tabular-nums">{year}</h2>
       <ul class="mt-3">
         {yearPosts.map((p) => (
-          <li class="flex items-center gap-4 border-b border-rule py-2.5">
-            <span class="label w-16 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(p.data.date)}</span>
-            {p.data.image ? (
-              <img src={p.data.image} alt="" loading="lazy" decoding="async" class="h-10 w-10 shrink-0 rounded-sm object-cover ring-1 ring-rule" />
-            ) : (
-              <span class="hidden h-10 w-10 shrink-0 sm:block" aria-hidden="true"></span>
-            )}
-            <a href={`/${p.data.permalink}/`} class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline">{p.data.title}</a>
+          <li class="border-b border-rule py-2.5">
+            <a href={`/${p.data.permalink}/`} class="group flex items-center gap-4">
+              <span class="label w-16 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(p.data.date)}</span>
+              <ThumbnailCard src={p.data.image} />
+              <span class="decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{p.data.title}</span>
+            </a>
           </li>
         ))}
       </ul>

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
+import ThumbnailCard from '../../components/ThumbnailCard.astro';
 import { collectTaxonomy, postsForTerm } from '../../lib/posts';
 
 export async function getStaticPaths() {
@@ -23,9 +24,12 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
   </section>
   <ul class="mt-6">
     {posts.map((p) => (
-      <li class="flex gap-4 border-b border-rule py-2.5">
-        <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(p.data.date)}</span>
-        <a href={`/${p.data.permalink}/`} class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline">{p.data.title}</a>
+      <li class="border-b border-rule py-2.5">
+        <a href={`/${p.data.permalink}/`} class="group flex items-center gap-4">
+          <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{fmt(p.data.date)}</span>
+          <ThumbnailCard src={p.data.image} />
+          <span class="decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{p.data.title}</span>
+        </a>
       </li>
     ))}
   </ul>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
 import Newsletter from '../../components/Newsletter.astro';
+import ThumbnailCard from '../../components/ThumbnailCard.astro';
 import { buildFieldGuide, collectTopics, type GuideItem } from '../../lib/writing';
 
 const writingEntries = await getCollection('writing');
@@ -38,11 +39,7 @@ const topics = collectTopics(writingEntries);
               rel={item.external ? 'noopener' : undefined}
               class="group flex items-start gap-4 border-b border-rule py-4 transition-colors hover:bg-panel"
             >
-              {item.image ? (
-                <img src={item.image} alt="" loading="lazy" decoding="async" class="h-10 w-10 shrink-0 rounded-sm object-cover ring-1 ring-rule" />
-              ) : (
-                <span class="hidden h-10 w-10 shrink-0 sm:block" aria-hidden="true"></span>
-              )}
+              <ThumbnailCard src={item.image} />
               <div class="min-w-0">
                 <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">
                   {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
@@ -63,11 +60,7 @@ const topics = collectTopics(writingEntries);
         {ungrouped.map((item: GuideItem) => (
           <li>
             <a href={item.href} class="group flex items-start gap-4 border-b border-rule py-4 transition-colors hover:bg-panel">
-              {item.image ? (
-                <img src={item.image} alt="" loading="lazy" decoding="async" class="h-10 w-10 shrink-0 rounded-sm object-cover ring-1 ring-rule" />
-              ) : (
-                <span class="hidden h-10 w-10 shrink-0 sm:block" aria-hidden="true"></span>
-              )}
+              <ThumbnailCard src={item.image} />
               <div class="min-w-0">
                 <h3 class="font-display text-lg font-medium decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">{item.title}</h3>
                 <p class="mt-1 text-ink-soft">{item.description}</p>

--- a/src/pages/writing/tags/[slug].astro
+++ b/src/pages/writing/tags/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '../../../layouts/Base.astro';
+import ThumbnailCard from '../../../components/ThumbnailCard.astro';
 import { collectTopics, writingForTopic } from '../../../lib/writing';
 
 export async function getStaticPaths() {
@@ -23,14 +24,17 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
   </section>
   <ul class="mt-6">
     {items.map((item) => (
-      <li class="flex gap-4 border-b border-rule py-2.5">
-        <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{item.pubDate ? fmt(item.pubDate) : ''}</span>
+      <li class="border-b border-rule py-2.5">
         <a
           href={item.href}
           rel={item.external ? 'noopener' : undefined}
-          class="decoration-accent-bright decoration-2 underline-offset-4 hover:underline"
+          class="group flex items-center gap-4"
         >
-          {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
+          <span class="label w-28 shrink-0 normal-case tracking-normal text-ink-soft">{item.pubDate ? fmt(item.pubDate) : ''}</span>
+          <ThumbnailCard src={item.image} />
+          <span class="decoration-accent-bright decoration-2 underline-offset-4 group-hover:underline">
+            {item.title}{item.external && <span class="label ml-2 align-middle normal-case tracking-normal text-ink-soft">tigerdata.com ↗</span>}
+          </span>
         </a>
       </li>
     ))}


### PR DESCRIPTION
## Summary
- Adds a shared `ThumbnailCard` component (aspect-video frame, `object-cover`, grayscale→color hover, graceful icon placeholder) used across every listing page: `/post/`, `/tags/*`, `/categories/*`, `/writing/`, `/writing/tags/*`. Replaces the old forced 40×40 square crop and adds thumbnails to pages that previously had none.
- `WritingLayout.astro` now renders `heroImage` as a real hero banner (aspect-video), matching `PostLayout.astro`'s existing pattern.
- Adds `heroInBody` to the `writing` schema (mirroring the `posts` schema) to suppress the hero on entries that already embed the cover image inline in the body — applied to the 17 existing crossposted writing posts so they don't show the cover twice.
- `scripts/crosspost-devto.ts` drops its inline-embed workaround now that `heroImage` actually renders; new crossposts will get the real hero going forward.

## Test plan
- [x] `npm run build` — 3165 pages built successfully
- [x] `npm test` — 62/62 tests pass
- [x] Verified via dev server: thumbnail cards render (image + placeholder states) on `/post/`, `/writing/`, `/writing/tags/[slug]`
- [x] Verified `zshrc-tour` writing post shows its cover image exactly once (hero correctly suppressed by `heroInBody`)

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)