### PR TITLE
Point devto-publish workflow at main ahead of default branch rename

### DIFF
--- a/.github/workflows/devto-publish.yml
+++ b/.github/workflows/devto-publish.yml
@@ -1,7 +1,7 @@
 name: Publish to dev.to
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths: ["mattstratton-dev-to/posts/**/*.md"]
 permissions:
   contents: write
@@ -18,5 +18,5 @@ jobs:
           devto_key: ${{ secrets.DEVTO_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "mattstratton-dev-to/posts/**/*.md"
-          branch: master
+          branch: main
           conventional_commits: true


### PR DESCRIPTION
## Summary
- Updates `devto-publish.yml` to trigger on / write back to `main` instead of `master`, in prep for renaming the default branch (#37)

## Test plan
- [ ] Merge to master
- [ ] Rename default branch master → main via GitHub API
- [ ] Confirm dev.to publish workflow still triggers correctly on the new branch